### PR TITLE
Handle rotation quirks on Kobos when out of Nickel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ endif
 ifdef STANDALONE
 	EXTRA_LDFLAGS+=-Wl,-rpath=/usr/local/fbink/lib
 endif
+# Maths!
+LIBS+=-lm
 
 ##
 # Now that we're done fiddling with flags, let's build stuff!

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,11 @@ endif
 ifdef STANDALONE
 	EXTRA_LDFLAGS+=-Wl,-rpath=/usr/local/fbink/lib
 endif
-# Maths!
-LIBS+=-lm
+# NOTE: Don't use in production, this was to help wrap my head around fb rotation experiments...
+ifdef MATHS
+	EXTRA_CPPFLAGS+=-DFBINK_WITH_MATHS
+	LIBS+=-lm
+endif
 
 ##
 # Now that we're done fiddling with flags, let's build stuff!

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The tool is available both as a commandline utility, and as a shared or static l
 See the [public header](fbink.h) for basic API usage.
 Launch the `fbink` tool with no argument for a quick manual & rundown of its capabilities.
 
-NOTE: It makes absolutely *NO* attempt at handling rotation, because that currently appears to be the right thing to do with both current Kobo FW versions and Kindles.
+NOTE: It generally makes absolutely *NO* attempt at handling rotation, because that currently appears to be the right thing to do with both current Kobo FW versions and Kindles.
 YMMV on older FW, or if something else is fudging with fb rotation, or if your application is implementing rotation in software (i.e., a rotated viewport).
 There's a very specific exception made for Kobo devices running in 16bpp mode and appearing to be in landscape mode: since that seems to be their native state,
 we *attempt* to compensate for this, as we can legitimately be used before Nickel itself corrects this.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Launch the `fbink` tool with no argument for a quick manual & rundown of its cap
 
 NOTE: It makes absolutely *NO* attempt at handling rotation, because that currently appears to be the right thing to do with both current Kobo FW versions and Kindles.
 YMMV on older FW, or if something else is fudging with fb rotation, or if your application is implementing rotation in software (i.e., a rotated viewport).
+There's a very specific exception made for Kobo devices running in 16bpp mode and appearing to be in landscape mode: since that seems to be their native state,
+we *attempt* to compensate for this, as we can legitimately be used before Nickel itself corrects this.
 
 # How does it look?
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The tool is available both as a commandline utility, and as a shared or static l
 See the [public header](fbink.h) for basic API usage.
 Launch the `fbink` tool with no argument for a quick manual & rundown of its capabilities.
 
-NOTE: It generally makes absolutely *NO* attempt at handling rotation, because that currently appears to be the right thing to do with both current Kobo FW versions and Kindles.
+NOTE: It generally makes *NO* attempt at handling rotation, because that currently appears to be the right thing to do with both current Kobo FW versions and Kindles.
 YMMV on older FW, or if something else is fudging with fb rotation, or if your application is implementing rotation in software (i.e., a rotated viewport).
 There's a very specific exception made for Kobo devices running in 16bpp mode and appearing to be in landscape mode: since that seems to be their native state,
 we *attempt* to compensate for this, as we can legitimately be used before Nickel itself corrects this.

--- a/fbink.c
+++ b/fbink.c
@@ -177,11 +177,13 @@ static void
 	//       when we're padding and centering, the final whitespace of right-padding will have its last
 	//       few pixels (the exact amount being half of the dead zone width) pushed off-screen...
 	if (coords.x >= vinfo.xres || coords.y >= vinfo.yres) {
+		/*
 		LOG("Discarding off-screen pixel @ (%hu, %hu) (out of %ux%u bounds)",
 		    coords.x,
 		    coords.y,
 		    vinfo.xres,
 		    vinfo.yres);
+		*/
 		return;
 	}
 #ifdef FBINK_FOR_LEGACY

--- a/fbink.c
+++ b/fbink.c
@@ -108,7 +108,7 @@ static void
     get_physical_coords(FBInkCoordinates* coords)
 {
 	unsigned short int rx = coords->y;
-	unsigned short int ry = viewHeight - coords->x - 1;
+	unsigned short int ry = viewWidth - coords->x - 1;
 
 	coords->x = rx;
 	coords->y = ry;

--- a/fbink.c
+++ b/fbink.c
@@ -904,14 +904,20 @@ int
 	// NOTE: But in some very specific circumstances, that doesn't hold true...
 	//       In particular, Kobos boot in Landscape orientation with coordinates still matching a portrait one...
 	if (vinfo.xres > vinfo.yres) {
-		// NOTE: vinfo.rotate == 2 (vs. 3 in Portrait mode) on my PW2
-		//       My Touch, which doesn't propose Landscape mode, defaults to vinfo.rotate == 1
-		//       My K4, which supports the four possible rotations,
-		//          is always using vinfo.rotate == 0 (but xres & yres do switch).
-		//       TL;DR: We can't really rely on rotate to tell us anything reliably actionable...
-		// NOTE: The Kobos, at boot, are in 16bpp mode, and appear to be natively rotated CCW
+		// NOTE: PW2:
+		//         vinfo.rotate == 2 in Landscape (vs. 3 in Portrait mode), w/ the xres/yres switch in Landscape,
+		//         and (0, 0) is always at the top-left of the viewport, so we're always correct.
+		//       Kindle Touch:
+		//         Doesn't propose a Landscape mode, and defaults to vinfo.rotate == 1
+		//       K4:
+		//         It supports the four possible rotations, and while it is always using vinfo.rotate == 0,
+		//         xres & yres switch accordingly when in Landscape modes,
+		//         and (0, 0) is always at the top-left of the viewport, so we're always correct.
+		//       TL;DR: We can't really rely on rotate to tell us anything reliably actionable, but, thankfully,
+		//              we don't have to do anything extra on Kindles anyway :).
+		// NOTE: The Kobos, on the other hand, at boot, are in 16bpp mode, and appear to be natively rotated CCW
 		//       (or CW, depending on how you look at it...).
-		//       Because we have legitimate uses in that state
+		//       Because we have legitimate uses in that state,
 		//       (be it during the boot process, i.e., on-animator; or out-of-Nickel use cases),
 		//       we attempt to handle this rotation properly, much like KOReader does.
 		//       c.f., https://github.com/koreader/koreader/blob/master/frontend/device/kobo/device.lua#L32-L33

--- a/fbink.c
+++ b/fbink.c
@@ -898,7 +898,14 @@ int
 	viewHeight = vinfo.yres;
 
 	// NOTE: But in some very specific circumstances, that doesn't hold true...
-	//       In particular, Kobos boot in Landscape orientation with coordinates still matching a portrait one...
+	//       In particular, Kobos boot with a framebuffer in Landscape orientation (i.e., xres > yres),
+	//       but a viewport in Portrait (the boot progress, as well as Nickel itself are presented in Portrait mode),
+	//       which leads to a broken origin: (0, 0) is at the top-right of the screen
+	//       (i.e., as if it were intended to be used in the same Landscape viewport as the framebuffer orientation).
+	//       So we have to handle the rotation ourselves. We limit this to Kobos and a simple xres > yres check,
+	//       because as we'll show, vinfo.rotate doesn't necessarily provides us with actionable info...
+	// NOTE: Nickel itself will put things back into order, so this should NOT affect behavior under Nickel...
+	//       Be aware that pickel, on the other hand, will forcibly drop back to this modeset!
 	if (vinfo.xres > vinfo.yres) {
 		// NOTE: PW2:
 		//         vinfo.rotate == 2 in Landscape (vs. 3 in Portrait mode), w/ the xres/yres switch in Landscape,

--- a/fbink.c
+++ b/fbink.c
@@ -836,6 +836,10 @@ int
 	     vinfo.rotate,
 	     fb_rotate_to_string(vinfo.rotate));
 
+	// NOTE: In most every cases, assume 0,0 is at the top-left of the screen, and xyes,yres at the bottom right.
+	viewWidth = vinfo.xres;
+	viewHeight = vinfo.yres;
+
 	// NOTE: Reset original font resolution, in case we're re-init'ing,
 	//       since we're relying on the default value to calculate the scaled value,
 	//       and we're using this value to set MAXCOLS & MAXROWS, which we *need* to be sane.
@@ -876,7 +880,15 @@ int
 			//       My Touch, which doesn't propose Landscape mode, defaults to vinfo.rotate == 1
 			//       My K4, which supports the four possible rotations,
 			//          is always using vinfo.rotate == 0 (but xres & yres do switch).
-			//screen_height = vinfo.xres;
+			// NOTE: Here be dragons!
+#if !defined(FBINK_FOR_KINDLE) && !defined(FBINK_FOR_LEGACY)
+			if (vinfo.bits_per_pixel == 16) {
+				viewWidth = vinfo.yres;
+				viewHeight = vinfo.xres;
+				deviceQuirks.isKobo16Landscape = true;
+				ELOG("[FBInk] Enabled Kobo 16bpp fb rotation device quirks");
+			}
+#endif
 		}
 		if (actual_height <= 600U) {
 			FONTSIZE_MULT = 1U;    // 8x8

--- a/fbink.c
+++ b/fbink.c
@@ -111,12 +111,15 @@ static void
 	unsigned short int ry = (unsigned short int) (viewWidth - coords->x - 1);
 
 // NOTE: This codepath is not production ready, it was just an experiment to wrap my head around framebuffer rotation...
+//       In particular, only CW has been actually confirmed to behave properly,
+//       and region rotation is NOT handled properly/at all.
+//       TL;DR: This is for documentation purposes only, never build w/ MATHS defined ;).
 #ifdef FBINK_WITH_MATHS
 	unsigned short int rotation = FB_ROTATE_CW;
 	// i.e., θ (c.f., https://en.wikipedia.org/wiki/Cartesian_coordinate_system#Rotation)
 	double rangle = ((rotation * 90) * M_PI / 180.0);
-	double fxp = coords->x * cos(rangle) - coords->y * sin(rangle);
-	double fyp = coords->x * sin(rangle) + coords->y * cos(rangle);
+	double fxp    = coords->x * cos(rangle) - coords->y * sin(rangle);
+	double fyp    = coords->x * sin(rangle) + coords->y * cos(rangle);
 	LOG("(fxp, fyp) -> (%f, %f)", fxp, fyp);
 	switch (rotation) {
 		case FB_ROTATE_CW:
@@ -144,7 +147,13 @@ static void
 		yp = (unsigned short int) lround(fyp);
 	}
 
-	LOG("(x, y) -> (%hu, %hu) vs. (rx, ry) -> (%hu, %hu) vs. (x', y') -> (%hu, %hu)", coords->x, coords->y, rx, ry, xp, yp);
+	LOG("(x, y) -> (%hu, %hu) vs. (rx, ry) -> (%hu, %hu) vs. (x', y') -> (%hu, %hu)",
+	    coords->x,
+	    coords->y,
+	    rx,
+	    ry,
+	    xp,
+	    yp);
 
 	coords->x = xp;
 	coords->y = yp;
@@ -284,7 +293,7 @@ static void
 			break;
 	}
 #else
-	bitmap = font8x8_get_bitmap(codepoint);
+	bitmap    = font8x8_get_bitmap(codepoint);
 #endif
 
 	unsigned short int x;

--- a/fbink.c
+++ b/fbink.c
@@ -167,6 +167,7 @@ static void
 static void
     put_pixel(unsigned short int x, unsigned short int y, unsigned short int c)
 {
+	// Handle rotation now, so we can properly validate if the pixel is off-screen or not ;).
 	FBInkCoordinates coords = { x, y };
 	if (deviceQuirks.isKobo16Landscape) {
 		rotate_coordinates(&coords);

--- a/fbink.c
+++ b/fbink.c
@@ -128,7 +128,7 @@ static void
 	//       when we're padding and centering, the final whitespace of right-padding will have its last
 	//       few pixels (the exact amount being half of the dead zone width) pushed off-screen...
 	if (coords.x >= vinfo.xres || coords.y >= vinfo.yres) {
-		LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)", coords.x, coords.y, vinfo.xres, vinfo.yres);
+		//LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)", coords.x, coords.y, vinfo.xres, vinfo.yres);
 		return;
 	}
 #ifdef FBINK_FOR_LEGACY
@@ -1301,6 +1301,12 @@ int
 	// Rotate the region if need be...
 	if (deviceQuirks.isKobo16Landscape) {
 		struct mxcfb_rect oregion = region;
+		/*
+		FBInkCoordinates coords = { oregion.left, oregion.top };
+		get_physical_coords(&coords);
+		region.top = coords.x;
+		region.left = coords.y;
+		*/
 		region.top = oregion.left;
 		region.left = oregion.top;
 		region.width = oregion.height;

--- a/fbink.c
+++ b/fbink.c
@@ -158,14 +158,19 @@ static void
 	      unsigned short int h,
 	      unsigned short int c)
 {
+	FBInkCoordinates coords = { x, y };
+	if (deviceQuirks.isKindleOasis2) {
+		get_physical_coords(&coords);
+	}
+
 	unsigned short int cx;
 	unsigned short int cy;
 	for (cy = 0U; cy < h; cy++) {
 		for (cx = 0U; cx < w; cx++) {
-			put_pixel((unsigned short int) (x + cx), (unsigned short int) (y + cy), c);
+			put_pixel((unsigned short int) (coords.x + cx), (unsigned short int) (coords.y + cy), c);
 		}
 	}
-	LOG("Filled a %hux%hu rectangle @ %hu, %hu", w, h, x, y);
+	LOG("Filled a %hux%hu rectangle @ %hu, %hu", w, h, coords.x, coords.y);
 }
 
 // Helper function to clear the screen - fill whole screen with given color
@@ -879,6 +884,7 @@ int
 		// Set font-size based on screen resolution (roughly matches: Pearl, Carta, Carta HD & 7" Carta, 7" Carta HD)
 		// NOTE: We still want to compare against the screen's "height", even in Landscape mode...
 		uint32_t actual_height = MAX(vinfo.xres, vinfo.yres);
+		//deviceQuirks.isKobo16Landscape = true;
 		if (vinfo.xres > vinfo.yres) {
 			// NOTE: vinfo.rotate == 2 (vs. 3 in Portrait mode) on my PW2
 			//       My Touch, which doesn't propose Landscape mode, defaults to vinfo.rotate == 1

--- a/fbink.c
+++ b/fbink.c
@@ -870,19 +870,19 @@ int
 	} else {
 		// Set font-size based on screen resolution (roughly matches: Pearl, Carta, Carta HD & 7" Carta, 7" Carta HD)
 		// NOTE: We still want to compare against the screen's "height", even in Landscape mode...
-		uint32_t screen_height = vinfo.yres;
+		uint32_t actual_height = MAX(vinfo.xres, vinfo.yres);
 		if (vinfo.xres > vinfo.yres) {
 			// NOTE: vinfo.rotate == 2 (vs. 3 in Portrait mode) on my PW2
 			//       My Touch, which doesn't propose Landscape mode, defaults to vinfo.rotate == 1
 			//       My K4, which supports the four possible rotations,
 			//          is always using vinfo.rotate == 0 (but xres & yres do switch).
-			screen_height = vinfo.xres;
+			//screen_height = vinfo.xres;
 		}
-		if (screen_height <= 600U) {
+		if (actual_height <= 600U) {
 			FONTSIZE_MULT = 1U;    // 8x8
-		} else if (screen_height <= 1024U) {
+		} else if (actual_height <= 1024U) {
 			FONTSIZE_MULT = 2U;    // 16x16
-		} else if (screen_height <= 1440U) {
+		} else if (actual_height <= 1440U) {
 			FONTSIZE_MULT = 3U;    // 24x24
 		} else {
 			FONTSIZE_MULT = 4U;    // 32x32

--- a/fbink.c
+++ b/fbink.c
@@ -893,7 +893,7 @@ int
 	     fb_rotate_to_string(vinfo.rotate));
 
 	// NOTE: In most every cases, we assume (0, 0) is at the top left of the screen,
-	//       and (xres, yres) at the bottom right.
+	//       and (xres, yres) at the bottom right, as we should.
 	viewWidth  = vinfo.xres;
 	viewHeight = vinfo.yres;
 

--- a/fbink.c
+++ b/fbink.c
@@ -110,6 +110,14 @@ static void
 	unsigned short int rx = coords->y;
 	unsigned short int ry = (unsigned short int) (viewWidth - coords->x - 1);
 
+	// i.e., θ (c.f., https://en.wikipedia.org/wiki/Cartesian_coordinate_system#Rotation)
+	double rangle = ((FB_ROTATE_CW * 90) * M_PI / 180.0);
+	// NOTE: We want unsigned values, so abs(); and lround is needed to avoid off-by-ones because of the float-to-uint conversion
+	unsigned short int xp = lround(fabs(coords->x * cos(rangle) - coords->y * sin(rangle)));
+	unsigned short int yp = vinfo.yres - 1 - lround(fabs(coords->x * sin(rangle) + coords->y * cos(rangle)));
+
+	LOG("(x, y) -> (%hu, %hu) vs. (rx, ry) -> (%hu, %hu) vs. (x', y') -> (%hu, %hu)", coords->x, coords->y, rx, ry, xp, yp);
+
 	coords->x = rx;
 	coords->y = ry;
 }

--- a/fbink.c
+++ b/fbink.c
@@ -300,7 +300,7 @@ static struct mxcfb_rect
 	if (!deviceQuirks.isPerfectFit) {
 		// We correct by half of said dead space, since we want perfect centering ;).
 		unsigned short int deadzone_offset =
-		    (unsigned short int) (vinfo.xres - (unsigned short int) (MAXCOLS * FONTW)) / 2U;
+		    (unsigned short int) (viewWidth - (unsigned short int) (MAXCOLS * FONTW)) / 2U;
 		pixel_offset = (unsigned short int) (pixel_offset + deadzone_offset);
 		LOG("Incrementing pixel_offset by %u pixels to compensate for dead space on the right edge",
 		    deadzone_offset);
@@ -310,7 +310,7 @@ static struct mxcfb_rect
 	struct mxcfb_rect region = {
 		.top   = (uint32_t)((row - multiline_offset) * FONTH),
 		.left  = (uint32_t)(col * FONTW),
-		.width = multiline_offset > 0U ? (vinfo.xres - (uint32_t)(col * FONTW)) : (uint32_t)(charcount * FONTW),
+		.width = multiline_offset > 0U ? (viewWidth - (uint32_t)(col * FONTW)) : (uint32_t)(charcount * FONTW),
 		.height = (uint32_t)((multiline_offset + 1U) * FONTH),
 	};
 
@@ -362,7 +362,7 @@ static struct mxcfb_rect
 	if (charcount == MAXCOLS && !deviceQuirks.isPerfectFit && !halfcell_offset) {
 		// NOTE: !isPerfectFit ensures pixel_offset is non-zero
 		LOG("Painting a background rectangle to fill the dead space on the right edge");
-		fill_rect((unsigned short int) (vinfo.xres - pixel_offset),
+		fill_rect((unsigned short int) (viewWidth - pixel_offset),
 			  (unsigned short int) (region.top + (unsigned short int) (multiline_offset * FONTH)),
 			  pixel_offset,
 			  FONTH,
@@ -906,12 +906,12 @@ int
 	ELOG("[FBInk] Fontsize set to %dx%d.", FONTW, FONTH);
 
 	// Compute MAX* values now that we know the screen & font resolution
-	MAXCOLS = (unsigned short int) (vinfo.xres / FONTW);
-	MAXROWS = (unsigned short int) (vinfo.yres / FONTH);
+	MAXCOLS = (unsigned short int) (viewWidth / FONTW);
+	MAXROWS = (unsigned short int) (viewHeight / FONTH);
 	ELOG("[FBInk] Line length: %hu cols, Page size: %hu rows.", MAXCOLS, MAXROWS);
 
 	// Mention & remember if we can perfectly fit the final column on screen
-	if ((unsigned short int) (FONTW * MAXCOLS) == vinfo.xres) {
+	if ((unsigned short int) (FONTW * MAXCOLS) == viewWidth) {
 		deviceQuirks.isPerfectFit = true;
 		ELOG("[FBInk] It's a perfect fit!");
 	}

--- a/fbink.c
+++ b/fbink.c
@@ -105,7 +105,7 @@ static void
 
 // Handle rotation quirks...
 static void
-    get_physical_coords(FBInkCoordinates* coords)
+    rotate_coordinates(FBInkCoordinates* coords)
 {
 	unsigned short int rx = coords->y;
 	unsigned short int ry = viewWidth - coords->x - 1;
@@ -120,7 +120,7 @@ static void
 {
 	FBInkCoordinates coords = { x, y };
 	if (deviceQuirks.isKobo16Landscape) {
-		get_physical_coords(&coords);
+		rotate_coordinates(&coords);
 	}
 
 	// NOTE: Discard off-screen pixels!
@@ -1302,14 +1302,7 @@ int
 	// Rotate the region if need be...
 	if (deviceQuirks.isKobo16Landscape) {
 		struct mxcfb_rect oregion = region;
-		// left = x
-		// top = y
-		/*
-		FBInkCoordinates coords = { oregion.left, oregion.top };
-		get_physical_coords(&coords);
-		region.top = coords.x;
-		region.left = coords.y;
-		*/
+		// NOTE: left = x, top = y
 		region.top    = viewWidth - oregion.left - oregion.width;
 		region.left   = oregion.top;
 		region.width  = oregion.height;

--- a/fbink.c
+++ b/fbink.c
@@ -128,7 +128,7 @@ static void
 	//       when we're padding and centering, the final whitespace of right-padding will have its last
 	//       few pixels (the exact amount being half of the dead zone width) pushed off-screen...
 	if (coords.x >= vinfo.xres || coords.y >= vinfo.yres) {
-		LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)",
+		LOG("Discarding off-screen pixel @ (%hu, %hu) (out of %ux%u bounds)",
 		    coords.x,
 		    coords.y,
 		    vinfo.xres,
@@ -169,7 +169,7 @@ static void
 			put_pixel((unsigned short int) (x + cx), (unsigned short int) (y + cy), c);
 		}
 	}
-	LOG("Filled a %hux%hu rectangle @ %hu, %hu", w, h, x, y);
+	LOG("Filled a %hux%hu rectangle @ (%hu, %hu)", w, h, x, y);
 }
 
 // Helper function to clear the screen - fill whole screen with given color

--- a/fbink.c
+++ b/fbink.c
@@ -1296,8 +1296,17 @@ int
 		free(line);
 	}
 
+	// Rotate the region if need be...
+	if (deviceQuirks.isKobo16Landscape) {
+		struct mxcfb_rect oregion = region;
+		region.top = oregion.left;
+		region.left = oregion.top;
+		region.width = oregion.height;
+		region.height = oregion.width;
+	}
+
 	// Fudge the region if we asked for a screen clear, so that we actually refresh the full screen...
-	if (fbink_config->is_cleared || deviceQuirks.isKobo16Landscape) {
+	if (fbink_config->is_cleared) {
 		region.top    = 0U;
 		region.left   = 0U;
 		region.width  = vinfo.xres;

--- a/fbink.c
+++ b/fbink.c
@@ -844,7 +844,7 @@ int
 	     vinfo.rotate,
 	     fb_rotate_to_string(vinfo.rotate));
 
-	// NOTE: In most every cases, assume 0,0 is at the top-left of the screen, and xyes,yres at the bottom right.
+	// NOTE: In most every cases, assume 0,0 is at the top left of the screen, and xres,yres at the bottom right.
 	viewWidth  = vinfo.xres;
 	viewHeight = vinfo.yres;
 

--- a/fbink.c
+++ b/fbink.c
@@ -159,9 +159,11 @@ static void
 	      unsigned short int c)
 {
 	FBInkCoordinates coords = { x, y };
+	/*
 	if (deviceQuirks.isKobo16Landscape) {
 		get_physical_coords(&coords);
 	}
+	*/
 
 	unsigned short int cx;
 	unsigned short int cy;
@@ -351,13 +353,13 @@ static struct mxcfb_rect
 			  FONTH,
 			  bgC);
 		// Correct width, to include that bit of content, too, if needed
-		if (region.width < vinfo.xres) {
+		if (region.width < viewWidth) {
 			region.width += pixel_offset;
 			// And make sure it's properly clamped, because we can't necessarily rely on left & width
 			// being entirely acurate either because of the multiline print override,
 			// or because of a bit of subcell placement overshoot trickery (c.f., comment in put_pixel).
-			if (region.width + region.left > vinfo.xres) {
-				region.width = vinfo.xres - region.left;
+			if (region.width + region.left > viewWidth) {
+				region.width = viewWidth - region.left;
 				LOG("Clamped region.width to %u", region.width);
 			} else {
 				LOG("Updated region.width to %u", region.width);
@@ -378,8 +380,8 @@ static struct mxcfb_rect
 			  bgC);
 		// If it's not already the case, update region to the full width,
 		// because we've just plugged a hole at the very right edge of a full line.
-		if (region.width < vinfo.xres) {
-			region.width = vinfo.xres;
+		if (region.width < viewWidth) {
+			region.width = viewWidth;
 			LOG("Updated region.width to %u", region.width);
 		}
 	}
@@ -387,9 +389,9 @@ static struct mxcfb_rect
 	// NOTE: In case of a multi-line centered print, we can't really trust the final col,
 	//       it might be significantly different than the others, and as such, we'd be computing a cropped region.
 	//       Make the region cover the full width of the screen to make sure we won't miss anything.
-	if (multiline_offset > 0U && is_centered && (region.left > 0U || region.width < vinfo.xres)) {
+	if (multiline_offset > 0U && is_centered && (region.left > 0U || region.width < viewWidth)) {
 		region.left  = 0U;
-		region.width = vinfo.xres;
+		region.width = viewWidth;
 		LOG("Enforced region.left to %u & region.width to %u because of multi-line centering",
 		    region.left,
 		    region.width);

--- a/fbink.c
+++ b/fbink.c
@@ -129,6 +129,7 @@ static void
 			yp = (unsigned short int) lround(vinfo.yres - 1 - fyp);
 			break;
 		case FB_ROTATE_UD:
+			// NOTE: IIRC, this pretty much ends up with (x', y') being equal to (y, x).
 			xp = (unsigned short int) lround(-fyp);
 			yp = (unsigned short int) lround(-fxp);
 			break;
@@ -137,6 +138,8 @@ static void
 			yp = (unsigned short int) lround(-fyp);
 			break;
 		default:
+			xp = (unsigned short int) lround(fxp);
+			yp = (unsigned short int) lround(fyp);
 			break;
 	}
 

--- a/fbink.c
+++ b/fbink.c
@@ -884,7 +884,6 @@ int
 		// Set font-size based on screen resolution (roughly matches: Pearl, Carta, Carta HD & 7" Carta, 7" Carta HD)
 		// NOTE: We still want to compare against the screen's "height", even in Landscape mode...
 		uint32_t actual_height = MAX(vinfo.xres, vinfo.yres);
-		//deviceQuirks.isKobo16Landscape = true;
 		if (vinfo.xres > vinfo.yres) {
 			// NOTE: vinfo.rotate == 2 (vs. 3 in Portrait mode) on my PW2
 			//       My Touch, which doesn't propose Landscape mode, defaults to vinfo.rotate == 1

--- a/fbink.c
+++ b/fbink.c
@@ -108,7 +108,7 @@ static void
     rotate_coordinates(FBInkCoordinates* coords)
 {
 	unsigned short int rx = coords->y;
-	unsigned short int ry = viewWidth - coords->x - 1;
+	unsigned short int ry = (unsigned short int) (viewWidth - coords->x - 1);
 
 	coords->x = rx;
 	coords->y = ry;

--- a/fbink.c
+++ b/fbink.c
@@ -895,7 +895,8 @@ int
 	     vinfo.rotate,
 	     fb_rotate_to_string(vinfo.rotate));
 
-	// NOTE: In most every cases, assume 0,0 is at the top left of the screen, and xres,yres at the bottom right.
+	// NOTE: In most every cases, we assume (0, 0) is at the top left of the screen,
+	//       and (xres, yres) at the bottom right.
 	viewWidth  = vinfo.xres;
 	viewHeight = vinfo.yres;
 
@@ -932,14 +933,21 @@ int
 #endif
 	} else {
 		// Set font-size based on screen resolution (roughly matches: Pearl, Carta, Carta HD & 7" Carta, 7" Carta HD)
-		// NOTE: We still want to compare against the screen's "height", even in Landscape mode...
+		// NOTE: We still want to compare against the screen's "height", even in Landscape mode,
+		//       so we simply use the longest edge to do just that...
 		uint32_t actual_height = MAX(vinfo.xres, vinfo.yres);
 		if (vinfo.xres > vinfo.yres) {
 			// NOTE: vinfo.rotate == 2 (vs. 3 in Portrait mode) on my PW2
 			//       My Touch, which doesn't propose Landscape mode, defaults to vinfo.rotate == 1
 			//       My K4, which supports the four possible rotations,
 			//          is always using vinfo.rotate == 0 (but xres & yres do switch).
-			// NOTE: Here be dragons!
+			// NOTE: The Kobos, at boot, are in 16bpp mode, and appear to be natively rotated CCW
+			//       (or CW, depending on how you look at it...).
+			//       Because we have legitimate uses in that state
+			//       (be it during the boot process, i.e., on-animator; or out-of-Nickel use cases),
+			//       we attempt to handle this rotation properly, much like KOReader does.
+			//       c.f., https://github.com/koreader/koreader/blob/master/frontend/device/kobo/device.lua#L32-L33
+			//           & https://github.com/koreader/koreader-base/blob/master/ffi/framebuffer.lua#L74-L84
 #if !defined(FBINK_FOR_KINDLE) && !defined(FBINK_FOR_LEGACY)
 			if (vinfo.bits_per_pixel == 16) {
 				viewWidth                      = vinfo.yres;

--- a/fbink.c
+++ b/fbink.c
@@ -128,7 +128,11 @@ static void
 	//       when we're padding and centering, the final whitespace of right-padding will have its last
 	//       few pixels (the exact amount being half of the dead zone width) pushed off-screen...
 	if (coords.x >= vinfo.xres || coords.y >= vinfo.yres) {
-		//LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)", coords.x, coords.y, vinfo.xres, vinfo.yres);
+		LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)",
+		    coords.x,
+		    coords.y,
+		    vinfo.xres,
+		    vinfo.yres);
 		return;
 	}
 #ifdef FBINK_FOR_LEGACY
@@ -158,21 +162,14 @@ static void
 	      unsigned short int h,
 	      unsigned short int c)
 {
-	FBInkCoordinates coords = { x, y };
-	/*
-	if (deviceQuirks.isKobo16Landscape) {
-		get_physical_coords(&coords);
-	}
-	*/
-
 	unsigned short int cx;
 	unsigned short int cy;
 	for (cy = 0U; cy < h; cy++) {
 		for (cx = 0U; cx < w; cx++) {
-			put_pixel((unsigned short int) (coords.x + cx), (unsigned short int) (coords.y + cy), c);
+			put_pixel((unsigned short int) (x + cx), (unsigned short int) (y + cy), c);
 		}
 	}
-	LOG("Filled a %hux%hu rectangle @ %hu, %hu", w, h, coords.x, coords.y);
+	LOG("Filled a %hux%hu rectangle @ %hu, %hu", w, h, x, y);
 }
 
 // Helper function to clear the screen - fill whole screen with given color
@@ -1301,15 +1298,17 @@ int
 	// Rotate the region if need be...
 	if (deviceQuirks.isKobo16Landscape) {
 		struct mxcfb_rect oregion = region;
+		// left = x
+		// top = y
 		/*
 		FBInkCoordinates coords = { oregion.left, oregion.top };
 		get_physical_coords(&coords);
 		region.top = coords.x;
 		region.left = coords.y;
 		*/
-		region.top = oregion.left;
-		region.left = oregion.top;
-		region.width = oregion.height;
+		region.top    = viewWidth - oregion.left - oregion.width;
+		region.left   = oregion.top;
+		region.width  = oregion.height;
 		region.height = oregion.width;
 	}
 

--- a/fbink.c
+++ b/fbink.c
@@ -1297,7 +1297,7 @@ int
 	}
 
 	// Fudge the region if we asked for a screen clear, so that we actually refresh the full screen...
-	if (fbink_config->is_cleared) {
+	if (fbink_config->is_cleared || deviceQuirks.isKobo16Landscape) {
 		region.top    = 0U;
 		region.left   = 0U;
 		region.width  = vinfo.xres;

--- a/fbink.c
+++ b/fbink.c
@@ -110,6 +110,8 @@ static void
 	unsigned short int rx = coords->y;
 	unsigned short int ry = (unsigned short int) (viewWidth - coords->x - 1);
 
+// NOTE: This codepath is not production ready, it was just an experiment to wrap my head around framebuffer rotation...
+#ifdef FBINK_WITH_MATHS
 	unsigned short int rotation = FB_ROTATE_CW;
 	// i.e., θ (c.f., https://en.wikipedia.org/wiki/Cartesian_coordinate_system#Rotation)
 	double rangle = ((rotation * 90) * M_PI / 180.0);
@@ -135,17 +137,21 @@ static void
 	unsigned short int xp;
 	unsigned short int yp;
 	if (rotation == FB_ROTATE_UD) {
-		xp = lround(fyp);
-		yp = lround(fxp);
+		xp = (unsigned short int) lround(fyp);
+		yp = (unsigned short int) lround(fxp);
 	} else {
-		xp = lround(fxp);
-		yp = lround(fyp);
+		xp = (unsigned short int) lround(fxp);
+		yp = (unsigned short int) lround(fyp);
 	}
 
 	LOG("(x, y) -> (%hu, %hu) vs. (rx, ry) -> (%hu, %hu) vs. (x', y') -> (%hu, %hu)", coords->x, coords->y, rx, ry, xp, yp);
 
 	coords->x = xp;
 	coords->y = yp;
+#else
+	coords->x = rx;
+	coords->y = ry;
+#endif
 }
 
 // Handle various bpp...

--- a/fbink.c
+++ b/fbink.c
@@ -118,23 +118,23 @@ static void
 static void
     put_pixel(unsigned short int x, unsigned short int y, unsigned short int c)
 {
+	FBInkCoordinates coords = { x, y };
+	if (deviceQuirks.isKobo16Landscape) {
+		get_physical_coords(&coords);
+	}
+
 	// NOTE: Discard off-screen pixels!
 	//       For instance, when we have a halfcell offset in conjunction with a !isPerfectFit pixel offset,
 	//       when we're padding and centering, the final whitespace of right-padding will have its last
 	//       few pixels (the exact amount being half of the dead zone width) pushed off-screen...
-	if (x >= vinfo.xres || y >= vinfo.yres) {
-		//LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)", x, y, vinfo.xres, vinfo.yres);
+	if (coords.x >= vinfo.xres || coords.y >= vinfo.yres) {
+		LOG("Discarding off-screen pixel @ %u, %u (out of %ux%u bounds)", coords.x, coords.y, vinfo.xres, vinfo.yres);
 		return;
 	}
 #ifdef FBINK_FOR_LEGACY
 	// NOTE: Legacy devices all have an inverted palette.
 	c = c ^ WHITE;
 #endif
-
-	FBInkCoordinates coords = { x, y };
-	if (deviceQuirks.isKindleOasis2) {
-		get_physical_coords(&coords);
-	}
 
 	if (vinfo.bits_per_pixel == 4U) {
 		put_pixel_Gray4(&coords, def_b[c]);
@@ -159,7 +159,7 @@ static void
 	      unsigned short int c)
 {
 	FBInkCoordinates coords = { x, y };
-	if (deviceQuirks.isKindleOasis2) {
+	if (deviceQuirks.isKobo16Landscape) {
 		get_physical_coords(&coords);
 	}
 

--- a/fbink.c
+++ b/fbink.c
@@ -894,7 +894,11 @@ int
 				viewWidth                      = vinfo.yres;
 				viewHeight                     = vinfo.xres;
 				deviceQuirks.isKobo16Landscape = true;
-				ELOG("[FBInk] Enabled Kobo 16bpp fb rotation device quirks");
+				ELOG("[FBInk] Enabled Kobo @ 16bpp fb rotation quirks (%ux%u -> %ux%u)",
+				     vinfo.xres,
+				     vinfo.yres,
+				     viewWidth,
+				     viewHeight);
 			}
 #endif
 		}
@@ -939,11 +943,11 @@ int
 		// Identify the device's specific model...
 		identify_device(&deviceQuirks);
 		if (deviceQuirks.isKindlePearlScreen) {
-			ELOG("[FBInk] Enabled Kindle with Pearl screen device quirks");
+			ELOG("[FBInk] Enabled Kindle with Pearl screen quirks");
 		} else if (deviceQuirks.isKindleOasis2) {
-			ELOG("[FBInk] Enabled Kindle Oasis 2 device quirks");
+			ELOG("[FBInk] Enabled Kindle Oasis 2 quirks");
 		} else if (deviceQuirks.isKoboMk7) {
-			ELOG("[FBInk] Enabled Kobo Mark 7 device quirks");
+			ELOG("[FBInk] Enabled Kobo Mark 7 quirks");
 		}
 
 		// Ask the Kernel for its HZ value so we can translate jiffies into human-readable units.

--- a/fbink.c
+++ b/fbink.c
@@ -111,7 +111,7 @@ static void
 	unsigned short int ry = (unsigned short int) (viewWidth - coords->x - 1);
 
 // NOTE: This codepath is not production ready, it was just an experiment to wrap my head around framebuffer rotation...
-//       In particular, only CW has been actually confirmed to behave properly,
+//       In particular, only CW has been actually confirmed to behave properly (to handle the isKobo16Landscape quirk),
 //       and region rotation is NOT handled properly/at all.
 //       TL;DR: This is for documentation purposes only, never build w/ MATHS defined ;).
 #ifdef FBINK_WITH_MATHS

--- a/fbink.c
+++ b/fbink.c
@@ -121,30 +121,23 @@ static void
 	double fxp    = coords->x * cos(rangle) - coords->y * sin(rangle);
 	double fyp    = coords->x * sin(rangle) + coords->y * cos(rangle);
 	LOG("(fxp, fyp) -> (%f, %f)", fxp, fyp);
+	unsigned short int xp;
+	unsigned short int yp;
 	switch (rotation) {
 		case FB_ROTATE_CW:
-			fxp = -fxp;
-			fyp = vinfo.yres - 1 - fyp;
+			xp = (unsigned short int) lround(-fxp);
+			yp = (unsigned short int) lround(vinfo.yres - 1 - fyp);
 			break;
 		case FB_ROTATE_UD:
-			fxp = -fxp;
-			fyp = -fyp;
+			xp = (unsigned short int) lround(-fyp);
+			yp = (unsigned short int) lround(-fxp);
 			break;
 		case FB_ROTATE_CCW:
-			fxp = vinfo.xres - 1 - fxp;
-			fyp = -fyp;
+			xp = (unsigned short int) lround(vinfo.xres - 1 - fxp);
+			yp = (unsigned short int) lround(-fyp);
 			break;
 		default:
 			break;
-	}
-	unsigned short int xp;
-	unsigned short int yp;
-	if (rotation == FB_ROTATE_UD) {
-		xp = (unsigned short int) lround(fyp);
-		yp = (unsigned short int) lround(fxp);
-	} else {
-		xp = (unsigned short int) lround(fxp);
-		yp = (unsigned short int) lround(fyp);
 	}
 
 	LOG("(x, y) -> (%hu, %hu) vs. (rx, ry) -> (%hu, %hu) vs. (x', y') -> (%hu, %hu)",
@@ -928,10 +921,10 @@ int
 			viewHeight                     = vinfo.xres;
 			deviceQuirks.isKobo16Landscape = true;
 			ELOG("[FBInk] Enabled Kobo @ 16bpp fb rotation quirks (%ux%u -> %ux%u)",
-			vinfo.xres,
-			vinfo.yres,
-			viewWidth,
-			viewHeight);
+			     vinfo.xres,
+			     vinfo.yres,
+			     viewWidth,
+			     viewHeight);
 		}
 #endif
 	}

--- a/fbink.c
+++ b/fbink.c
@@ -903,7 +903,7 @@ int
 	//       which leads to a broken origin: (0, 0) is at the top-right of the screen
 	//       (i.e., as if it were intended to be used in the same Landscape viewport as the framebuffer orientation).
 	//       So we have to handle the rotation ourselves. We limit this to Kobos and a simple xres > yres check,
-	//       because as we'll show, vinfo.rotate doesn't necessarily provides us with actionable info...
+	//       because as we'll show, vinfo.rotate doesn't necessarily provide us with actionable info...
 	// NOTE: Nickel itself will put things back into order, so this should NOT affect behavior under Nickel...
 	//       Be aware that pickel, on the other hand, will forcibly drop back to this modeset!
 	if (vinfo.xres > vinfo.yres) {
@@ -927,6 +927,7 @@ int
 		//           & https://github.com/koreader/koreader-base/blob/master/ffi/framebuffer.lua#L74-L84
 #if !defined(FBINK_FOR_KINDLE) && !defined(FBINK_FOR_LEGACY)
 		if (vinfo.bits_per_pixel == 16) {
+			// Correct viewWidth & viewHeight, so we do all our row/column arithmetics on the right values...
 			viewWidth                      = vinfo.yres;
 			viewHeight                     = vinfo.xres;
 			deviceQuirks.isKobo16Landscape = true;

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -32,7 +32,7 @@
 #include <fcntl.h>
 #include <linux/fb.h>
 #include <linux/kd.h>
-// NOTE: Doin't use in prod, c.f., Makefile
+// NOTE: Don't use in prod, c.f., Makefile & rotate_coordinates() comments in fbink.c
 #ifdef FBINK_WITH_MATHS
 #	include <math.h>
 #endif

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -148,6 +148,8 @@ bool           g_fbink_isFbMapped = false;
 // And those stay purely inside the library
 struct fb_var_screeninfo vinfo;
 struct fb_fix_screeninfo finfo;
+uint32_t viewWidth;
+uint32_t viewHeight;
 unsigned short int       FONTW         = 8U;
 unsigned short int       FONTH         = 8U;
 unsigned short int       FONTSIZE_MULT = 1U;

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -34,7 +34,7 @@
 #include <linux/kd.h>
 // NOTE: Doin't use in prod, c.f., Makefile
 #ifdef FBINK_WITH_MATHS
-#include <math.h>
+#	include <math.h>
 #endif
 #include <stdlib.h>
 #include <string.h>

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -32,7 +32,10 @@
 #include <fcntl.h>
 #include <linux/fb.h>
 #include <linux/kd.h>
+// NOTE: Doin't use in prod, c.f., Makefile
+#ifdef FBINK_WITH_MATHS
 #include <math.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -166,7 +166,7 @@ long int USER_HZ = 100;
 // Where we track device/screen-specific quirks
 FBInkDeviceQuirks deviceQuirks = { 0 };
 
-static void get_physical_coords(FBInkCoordinates*);
+static void rotate_coordinates(FBInkCoordinates*);
 
 static void put_pixel_Gray4(FBInkCoordinates*, unsigned short int);
 static void put_pixel_Gray8(FBInkCoordinates*, unsigned short int);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <linux/fb.h>
 #include <linux/kd.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -148,8 +148,8 @@ bool           g_fbink_isFbMapped = false;
 // And those stay purely inside the library
 struct fb_var_screeninfo vinfo;
 struct fb_fix_screeninfo finfo;
-uint32_t viewWidth;
-uint32_t viewHeight;
+uint32_t                 viewWidth;
+uint32_t                 viewHeight;
 unsigned short int       FONTW         = 8U;
 unsigned short int       FONTH         = 8U;
 unsigned short int       FONTSIZE_MULT = 1U;
@@ -166,23 +166,13 @@ long int USER_HZ = 100;
 // Where we track device/screen-specific quirks
 FBInkDeviceQuirks deviceQuirks = { 0 };
 
-static void put_pixel_Gray4(unsigned short int, unsigned short int, unsigned short int);
-static void put_pixel_Gray8(unsigned short int, unsigned short int, unsigned short int);
-static void put_pixel_RGB24(unsigned short int,
-			    unsigned short int,
-			    unsigned short int,
-			    unsigned short int,
-			    unsigned short int);
-static void put_pixel_RGB32(unsigned short int,
-			    unsigned short int,
-			    unsigned short int,
-			    unsigned short int,
-			    unsigned short int);
-static void put_pixel_RGB565(unsigned short int,
-			     unsigned short int,
-			     unsigned short int,
-			     unsigned short int,
-			     unsigned short int);
+static void get_physical_coords(FBInkCoordinates*);
+
+static void put_pixel_Gray4(FBInkCoordinates*, unsigned short int);
+static void put_pixel_Gray8(FBInkCoordinates*, unsigned short int);
+static void put_pixel_RGB24(FBInkCoordinates*, unsigned short int, unsigned short int, unsigned short int);
+static void put_pixel_RGB32(FBInkCoordinates*, unsigned short int, unsigned short int, unsigned short int);
+static void put_pixel_RGB565(FBInkCoordinates*, unsigned short int, unsigned short int, unsigned short int);
 static void put_pixel(unsigned short int, unsigned short int, unsigned short int);
 
 static void fill_rect(unsigned short int,

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -56,4 +56,11 @@ typedef struct
 	bool skipId;
 } FBInkDeviceQuirks;
 
+// x,y coordinates tuple
+typedef struct
+{
+	unsigned short int x;
+	unsigned short int y;
+} FBInkCoordinates;
+
 #endif

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -56,7 +56,7 @@ typedef struct
 	bool skipId;
 } FBInkDeviceQuirks;
 
-// x,y coordinates tuple
+// An (x, y) coordinates tuple
 typedef struct
 {
 	unsigned short int x;

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -52,6 +52,7 @@ typedef struct
 	bool isKoboMk7;
 	bool isKindlePearlScreen;
 	bool isKindleOasis2;
+	bool isKobo16Landscape;
 	bool skipId;
 } FBInkDeviceQuirks;
 


### PR DESCRIPTION
i.e., when they're in their native broken Landscape mode, @ 16bpp.