### PR TITLE
Added fbink_get_state() to dump FBInk internal  vars to a struct

### DIFF
--- a/fbink.c
+++ b/fbink.c
@@ -1808,7 +1808,7 @@ void
 		fbink_state->bpp            = vInfo.bits_per_pixel;
 		fbink_state->font_w         = FONTW;
 		fbink_state->font_h         = FONTH;
-		fbink_state->font_sz_mult   = FONTSIZE_MULT;
+		fbink_state->fontsize_mult   = FONTSIZE_MULT;
 		fbink_state->font_name      = fontname_to_string(fbink_config->fontname);
 		fbink_state->glyph_width    = glyphWidth;
 		fbink_state->glyph_height   = glyphHeight;

--- a/fbink.c
+++ b/fbink.c
@@ -1798,6 +1798,29 @@ void
 	    penBGColor);
 }
 
+// Dump a few of out internal state variables to struct pointed to by fbink_state
+void
+	fbink_get_state(const FBInkConfig* fbink_config, FBInkState* fbink_state)
+{
+	if (fbink_state) {
+		fbink_state->view_width     = viewWidth;
+		fbink_state->view_height    = viewHeight;
+		fbink_state->bpp            = vInfo.bits_per_pixel;
+		fbink_state->font_w         = FONTW;
+		fbink_state->font_h         = FONTH;
+		fbink_state->font_sz_mult   = FONTSIZE_MULT;
+		fbink_state->font_name      = fontname_to_string(fbink_config->fontname);
+		fbink_state->glyph_width    = glyphWidth;
+		fbink_state->glyph_height   = glyphHeight;
+		fbink_state->max_cols       = MAXCOLS;
+		fbink_state->max_rows       = MAXROWS;
+		fbink_state->is_perfect_fit = deviceQuirks.isPerfectFit;
+		fbink_state->user_hz        = USER_HZ;
+		fbink_state->pen_fg_color   = penFGColor;
+		fbink_state->pen_bg_color   = penBGColor;
+	}
+}
+
 // Memory map the framebuffer
 static int
     memmap_fb(int fbfd)

--- a/fbink.h
+++ b/fbink.h
@@ -135,7 +135,7 @@ typedef struct
 	uint32_t       bpp;
 	unsigned short font_w;
 	unsigned short font_h;
-	uint8_t        font_sz_mult;
+	uint8_t        fontsize_mult;
 	const char*    font_name;
 	uint8_t        glyph_width;
 	uint8_t        glyph_height;
@@ -209,7 +209,7 @@ FBINK_API int fbink_init(int fbfd, const FBInkConfig* fbink_config);
 // Dumps a few of our internal state variables to stdout, in a format easily consumable by a shell (i.e., eval)
 FBINK_API void fbink_state_dump(const FBInkConfig* fbink_config);
 
-// Dump a few of out internal state variables to struct pointed to by fbink_state
+// Dump a few of our internal state variables to struct pointed to by fbink_state
 FBINK_API void fbink_get_state(const FBInkConfig* fbink_config, FBInkState* fbink_state);
 
 // Print a string on screen.

--- a/fbink.h
+++ b/fbink.h
@@ -127,6 +127,26 @@ typedef enum
 	BG_BLACK
 } BG_COLOR_INDEX_T;
 
+// A struct to dump the FBInk state into, for when a shell isn't wanted
+typedef struct
+{
+	uint32_t       view_width;
+	uint32_t       view_height;
+	uint32_t       bpp;
+	unsigned short font_w;
+	unsigned short font_h;
+	uint8_t        font_sz_mult;
+	const char*    font_name;
+	uint8_t        glyph_width;
+	uint8_t        glyph_height;
+	unsigned short max_cols;
+	unsigned short max_rows;
+	bool           is_perfect_fit;
+	long           user_hz;
+	uint8_t        pen_fg_color;
+	uint8_t        pen_bg_color;
+} FBInkState;
+
 // What a FBInk config should look like. Perfectly sane when fully zero-initialized.
 typedef struct
 {
@@ -188,6 +208,9 @@ FBINK_API int fbink_init(int fbfd, const FBInkConfig* fbink_config);
 
 // Dumps a few of our internal state variables to stdout, in a format easily consumable by a shell (i.e., eval)
 FBINK_API void fbink_state_dump(const FBInkConfig* fbink_config);
+
+// Dump a few of out internal state variables to struct pointed to by fbink_state
+FBINK_API void fbink_get_state(const FBInkConfig* fbink_config, FBInkState* fbink_state);
 
 // Print a string on screen.
 // NOTE: The string is expected to be encoded in valid UTF-8, no validation of any kind is done by the library,


### PR DESCRIPTION
I'm in some situations when developing where knowing the framebuffer size/state would be really useful. FBInk already did this -- for shell users. 

I added a new function and struct to dump the information to said struct instead.

Let me know if you have any issues with it. Tested with a simple C test program on Linux (not on my Kobo)