### PR TITLE
Add ability to print image from image data in memory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cstdlib": "c"
+    }
+}

--- a/fbink.c
+++ b/fbink.c
@@ -2977,7 +2977,7 @@ int
 // Draw an image on screen
 int
     fbink_print_image_data(int fbfd    UNUSED_BY_MINIMAL,
-		      const char* data UNUSED_BY_MINIMAL,
+		      unsigned char* data UNUSED_BY_MINIMAL,
 		      short int x_off UNUSED_BY_MINIMAL,
 		      short int y_off    UNUSED_BY_MINIMAL,
 			  int w UNUSED_BY_MINIMAL,

--- a/fbink.c
+++ b/fbink.c
@@ -2826,6 +2826,36 @@ cleanup:
 }
 
 int
+	fbink_get_image_channels(const FBInkConfig* fbink_config UNUSED_BY_MINIMAL)
+{
+#ifdef FBINK_WITH_IMAGE
+	int req_n;
+	switch (vInfo.bits_per_pixel) {
+		case 4U:
+			req_n = 1 + !fbink_config->ignore_alpha;
+			break;
+		case 8U:
+			req_n = 1 + !fbink_config->ignore_alpha;
+			break;
+		case 16U:
+			req_n = 3 + !fbink_config->ignore_alpha;
+			break;
+		case 24U:
+			req_n = 3 + !fbink_config->ignore_alpha;
+			break;
+		case 32U:
+		default:
+			req_n = 3 + !fbink_config->ignore_alpha;
+			break;
+	}
+	return req_n;
+#else
+	fprintf(stderr, "[FBInk] Image support is disabled in this FBInk build!\n");
+	return ERRCODE(ENOSYS);
+#endif    // FBINK_WITH_IMAGE
+}
+
+int
     fbink_print_image(int fbfd    UNUSED_BY_MINIMAL,
 		      const char* filename UNUSED_BY_MINIMAL,
 		      short int x_off UNUSED_BY_MINIMAL,
@@ -2939,8 +2969,10 @@ int
 	LOG("Requested %d color channels, image had %d.", req_n, n);
 
 	return fbink_print_image_data(fbfd, data, x_off, y_off, w, h, n, req_n, fbink_config);
-
-#endif
+#else
+	fprintf(stderr, "[FBInk] Image support is disabled in this FBInk build!\n");
+	return ERRCODE(ENOSYS);
+#endif    // FBINK_WITH_IMAGE
 }
 // Draw an image on screen
 int

--- a/fbink.c
+++ b/fbink.c
@@ -2825,6 +2825,8 @@ cleanup:
 	return rv;
 }
 
+// Get the number of image channels required for the current framebuffer.
+// Used by those who call fbink_print_image_data() directly
 int
 	fbink_get_image_channels(const FBInkConfig* fbink_config UNUSED_BY_MINIMAL)
 {
@@ -2855,6 +2857,7 @@ int
 #endif    // FBINK_WITH_IMAGE
 }
 
+// Draw am image on the screen from a file
 int
     fbink_print_image(int fbfd    UNUSED_BY_MINIMAL,
 		      const char* filename UNUSED_BY_MINIMAL,

--- a/fbink.c
+++ b/fbink.c
@@ -2971,7 +2971,9 @@ int
 	}
 	LOG("Requested %d color channels, image had %d.", req_n, n);
 
-	return fbink_print_image_data(fbfd, data, x_off, y_off, w, h, n, req_n, fbink_config);
+	int rv = fbink_print_image_data(fbfd, data, x_off, y_off, w, h, n, req_n, fbink_config);
+	stbi_image_free(data);
+	return rv;
 #else
 	fprintf(stderr, "[FBInk] Image support is disabled in this FBInk build!\n");
 	return ERRCODE(ENOSYS);
@@ -3581,7 +3583,6 @@ int
 			}
 		}
 	}
-	stbi_image_free(data);
 
 	// Rotate the region if need be...
 	if (deviceQuirks.isKobo16Landscape) {

--- a/fbink.h
+++ b/fbink.h
@@ -317,7 +317,7 @@ FBINK_API int fbink_get_image_channels(const FBInkConfig* fbink_config);
 // w:			image width
 // h:			image height
 // n:			number of 8-bit color channels from original image
-// req_n:		number of 8-bit color channels data uses, as determined beforehand by
+// req_n:		number of 8-bit color channels data used, as determined beforehand by
 //				fbink_get_image_channels(). Callers are expected to prepare their image
 //				accordingly.
 // fbink_config:	pointer to an FBInkConfig struct (honors any combination of halign/valign, row/col & x_off/y_off)

--- a/fbink.h
+++ b/fbink.h
@@ -322,7 +322,7 @@ FBINK_API int fbink_get_image_channels(const FBInkConfig* fbink_config);
 //				accordingly.
 // fbink_config:	pointer to an FBInkConfig struct (honors any combination of halign/valign, row/col & x_off/y_off)
 FBINK_API int fbink_print_image_data(int fbfd,
-				const char*        data,
+				unsigned char*        data,
 				short int          x_off,
 				short int          y_off,
 				int w,

--- a/fbink.h
+++ b/fbink.h
@@ -127,6 +127,14 @@ typedef enum
 	BG_BLACK
 } BG_COLOR_INDEX_T;
 
+typedef enum
+{
+	GRAY = 1,
+	GRAY_ALPHA = 2,
+	RGB = 3,
+	RGBA = 4
+} COLOR_CHANNEL_T;
+
 // A struct to dump FBInk's internal state into, like fbink_state_dump() would, but in C ;)
 typedef struct
 {
@@ -276,7 +284,7 @@ FBINK_API int fbink_print_progress_bar(int fbfd, uint8_t percentage, const FBInk
 // fbink_config:	pointer to an FBInkConfig struct (ignores col & hoffset; as well as is_centered & is_padded).
 FBINK_API int fbink_print_activity_bar(int fbfd, uint8_t progress, const FBInkConfig* fbink_config);
 
-// Print an image on screen
+// Print an image on screen from an image file
 // Returns -(ENOSYS) when image support is disabled (MINIMAL build)
 // fdfd:		open file descriptor to the framebuffer character device,
 //				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call
@@ -292,6 +300,36 @@ FBINK_API int fbink_print_image(int                fbfd,
 				short int          y_off,
 				const FBInkConfig* fbink_config);
 
+// Return the number of colour channels fbink_print_image_data() expects,
+// considering the current state of the framebuffer.
+// Returns -(ENOSYS) when image support is disabled (MINIMAL build)
+// Returns a COLOR_CHANNEL_T
+// fbink_config: pointer to an FBInkConfig struct. Used to determine transparency setting
+FBINK_API int fbink_get_image_channels(const FBInkConfig* fbink_config);
+
+// Print an image on screen from data in memory
+// Returns -(ENOSYS) when image support is disabled (MINIMAL build)
+// fdfd:		open file descriptor to the framebuffer character device,
+//				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call
+// data:		pointer to an image with dimensions w and h, and req_n color channels
+// x_off:		target coordinates, x (honors negative offsets)
+// y_off:		target coordinates, y (honors negative offsets)
+// w:			image width
+// h:			image height
+// n:			number of 8-bit color channels from original image
+// req_n:		number of 8-bit color channels data uses, as determined beforehand by
+//				fbink_get_image_channels(). Callers are expected to prepare their image
+//				accordingly.
+// fbink_config:	pointer to an FBInkConfig struct (honors any combination of halign/valign, row/col & x_off/y_off)
+FBINK_API int fbink_print_image_data(int fbfd,
+				const char*        data,
+				short int          x_off,
+				short int          y_off,
+				int w,
+				int h,
+				int n,
+				int req_n,
+				const FBInkConfig* fbink_config);
 // Scan the screen for Kobo's "Connect" button in the "USB plugged in" popup,
 // and optionally generate an input event to press that button.
 // KOBO Only! Returns -(ENOSYS) when disabled (!KOBO, as well as MINIMAL builds).


### PR DESCRIPTION
This PR adds the ability for FBInk to print an image given a pointer to an image in memory.

What I've done is extract the STB image loading out of the main printing function. The main printing function has been renamed to `fbink_print_image_data()`. The STB loading function keeps the original `fbink_print_image()` function signature, to maintain backwards compatibility.

`fbink_print_image()` now loads the image from a file, and then calls `fbink_print_image_data()`. Alternatively, users can call `fbink_print_image_data()` directly if they do not wish to load an image from file.

`fbink_get_image_channels()` has been added to assist callers of `fbink_print_image_data()`, so that they know what image format should be supplied.

Tested on my H2O, with RGBA at least. File loading still appears to work fine, so hopefully I haven't broken anything!