### PR TITLE
add support for bq cervantes and fnac touch devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ endif
 ifdef LEGACY
 	EXTRA_CPPFLAGS+=-DFBINK_FOR_LEGACY
 endif
+# Toggle Bq Cervantes support
+ifdef CERVANTES
+    EXTRA_CPPFLAGS+=-DFBINK_FOR_CERVANTES
+endif
 # Toggle generic Linux support
 ifdef LINUX
 	EXTRA_CPPFLAGS+=-DFBINK_FOR_LINUX
@@ -139,12 +143,12 @@ endif
 FBINK_VERSION=$(shell git describe)
 ifdef KINDLE
 	LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for Kindle"'
-else
-ifdef LINUX
-	LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for Linux"'
-else
+else ifdef KOBO
 	LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for Kobo"'
-endif
+else ifdef CERVANTES
+    LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for Cervantes"'
+else ifdef LINUX
+	LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for Linux"'
 endif
 
 # NOTE: Always use as-needed to avoid unecessary DT_NEEDED entries :)
@@ -289,6 +293,9 @@ legacy:
 linux:
 	$(MAKE) strip LINUX=true
 
+cervantes:
+	$(MAKE) strip CERVANTES=true
+
 kobo: release
 	mkdir -p Kobo/usr/local/fbink/bin Kobo/usr/bin Kobo/usr/local/fbink/lib
 	cp -av $(CURDIR)/Release/fbink Kobo/usr/local/fbink/bin
@@ -329,4 +336,4 @@ clean:
 	rm -rf Debug/*.o
 	rm -rf Debug/fbink
 
-.PHONY: default outdir all staticlib sharedlib static shared striplib striparchive stripbin strip debug static pic shared release kindle legacy linux kobo clean
+.PHONY: default outdir all staticlib sharedlib static shared striplib striparchive stripbin strip debug static pic shared release kindle legacy cervantes linux kobo clean

--- a/eink/mxcfb-cervantes.h
+++ b/eink/mxcfb-cervantes.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2004-2013 Freescale Semiconductor, Inc. All Rights Reserved.
+ *
+ * Unified header for BQ Cervantes/Fnac Touchlight devices
+ * Heavily based on mxcfb-kobo.h, with some notes from  bq kernel sources.
+ *
+ * The code contained herein is licensed under the GNU Lesser General
+ * Public License.  You may obtain a copy of the GNU Lesser General
+ * Public License Version 2.1 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/lgpl-license.html
+ * http://www.gnu.org/copyleft/lgpl.html
+ */
+
+/*
+ * @file arch-mxc/   mxcfb.h
+ *
+ * @brief Global header file for the MXC Frame buffer
+ *
+ * @ingroup Framebuffer
+ */
+#ifndef __ASM_ARCH_MXCFB_H__
+#define __ASM_ARCH_MXCFB_H__
+
+#define FB_SYNC_OE_LOW_ACT	0x80000000
+#define FB_SYNC_CLK_LAT_FALL	0x40000000
+#define FB_SYNC_DATA_INVERT	0x20000000
+#define FB_SYNC_CLK_IDLE_EN	0x10000000
+#define FB_SYNC_SHARP_MODE	0x08000000
+#define FB_SYNC_SWAP_RGB	0x04000000
+
+// Cervantes 2013/Fnac Touch Light and higher
+#define FB_ACCEL_TRIPLE_FLAG	0x00000000
+#define FB_ACCEL_DOUBLE_FLAG	0x00000001
+
+struct mxcfb_gbl_alpha {
+	int enable;
+	int alpha;
+};
+
+struct mxcfb_loc_alpha {
+	int enable;
+	int alpha_in_pixel;
+	unsigned long alpha_phy_addr0;
+	unsigned long alpha_phy_addr1;
+};
+
+struct mxcfb_color_key {
+	int enable;
+	__u32 color_key;
+};
+
+struct mxcfb_pos {
+	__u16 x;
+	__u16 y;
+};
+
+struct mxcfb_gamma {
+	int enable;
+	int constk[16];
+	int slopek[16];
+};
+
+struct mxcfb_rect {
+	__u32 top;
+	__u32 left;
+	__u32 width;
+	__u32 height;
+};
+
+#define GRAYSCALE_8BIT			0x1
+#define GRAYSCALE_8BIT_INVERTED		0x2
+#define GRAYSCALE_4BIT                  0x3
+#define GRAYSCALE_4BIT_INVERTED         0x4
+
+#define AUTO_UPDATE_MODE_REGION_MODE	0
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE 1
+
+#define UPDATE_SCHEME_SNAPSHOT		0
+#define UPDATE_SCHEME_QUEUE		1
+#define UPDATE_SCHEME_QUEUE_AND_MERGE	2
+
+#define UPDATE_MODE_PARTIAL		0x0
+#define UPDATE_MODE_FULL		0x1
+
+/* Those are sneaked in in drivers/video/mxc/mxc_epdc_fb.c  == Kobo */
+#define NTX_WFM_MODE_INIT		0
+#define NTX_WFM_MODE_DU			1
+#define NTX_WFM_MODE_GC16		2
+#define NTX_WFM_MODE_GC4		3
+#define NTX_WFM_MODE_A2			4
+#define NTX_WFM_MODE_GL16		5
+#define NTX_WFM_MODE_GLR16		6
+#define NTX_WFM_MODE_GLD16		7
+#define NTX_WFM_MODE_TOTAL		8
+
+/* Match 'em to the Kindle ones, for sanity's sake... */
+#define WAVEFORM_MODE_INIT      	NTX_WFM_MODE_INIT
+#define WAVEFORM_MODE_DU        	NTX_WFM_MODE_DU
+#define WAVEFORM_MODE_GC4      		NTX_WFM_MODE_GC4
+#define WAVEFORM_MODE_GC16		NTX_WFM_MODE_GC16
+#define WAVEFORM_MODE_A2        	NTX_WFM_MODE_A2
+#define WAVEFORM_MODE_GL16      	NTX_WFM_MODE_GL16
+
+// for cervantes 2013
+#define WAVEFORM_MODE_REAGL     	NTX_WFM_MODE_GLR16
+#define WAVEFORM_MODE_REAGLD    	NTX_WFM_MODE_GLD16
+
+// for cervantes 3+
+#define WAVEFORM_MODE_AA        	NTX_WFM_MODE_GLR16
+#define WAVEFORM_MODE_GLR16		NTX_WFM_MODE_GLR16
+#define WAVEFORM_MODE_AAD       	NTX_WFM_MODE_GLD16
+#define WAVEFORM_MODE_GLD16		NTX_WFM_MODE_GLD16
+
+#define WAVEFORM_MODE_AUTO		257
+
+#define TEMP_USE_AMBIENT		0x1000
+
+#define EPDC_FLAG_ENABLE_INVERSION	0x01
+#define EPDC_FLAG_FORCE_MONOCHROME	0x02
+#define EPDC_FLAG_USE_CMAP		0x04
+#define EPDC_FLAG_USE_ALT_BUFFER	0x100
+#define EPDC_FLAG_TEST_COLLISION	0x200
+#define EPDC_FLAG_GROUP_UPDATE		0x400
+#define EPDC_FLAG_USE_DITHERING_Y1	0x2000
+#define EPDC_FLAG_USE_DITHERING_Y4	0x4000
+#define EPDC_FLAG_USE_REGAL		0x8000 // not present - copied from mxcfb-kobo.h
+
+// new stuff (2016+)
+#define EPDC_FLAG_USE_AAD		0x1000
+#define EPDC_FLAG_USE_DITHERING_NTX_D8	0x100000
+
+enum mxcfb_dithering_mode { // not present - copied from mxcfb-kobo.h
+        EPDC_FLAG_USE_DITHERING_PASSTHROUGH = 0x0,
+        EPDC_FLAG_USE_DITHERING_FLOYD_STEINBERG,
+        EPDC_FLAG_USE_DITHERING_ATKINSON,
+        EPDC_FLAG_USE_DITHERING_ORDERED,
+        EPDC_FLAG_USE_DITHERING_QUANT_ONLY,
+        EPDC_FLAG_USE_DITHERING_MAX,
+};
+
+#define FB_POWERDOWN_DISABLE			-1
+
+struct mxcfb_alt_buffer_data {
+	void *virt_addr;
+	__u32 phys_addr;
+	__u32 width;	/* width of entire buffer */
+	__u32 height;	/* height of entire buffer */
+	struct mxcfb_rect alt_update_region;	/* region within buffer to update */
+};
+
+struct mxcfb_update_data {
+	struct mxcfb_rect update_region;
+	__u32 waveform_mode;
+	__u32 update_mode;
+	__u32 update_marker;
+	int temp;
+	unsigned int flags;
+	struct mxcfb_alt_buffer_data alt_buffer_data;
+};
+
+// begin of new stuff (2016+) -> isCervantesNew
+struct mxcfb_alt_buffer_data_org {
+	__u32 phys_addr;
+	__u32 width;	/* width of entire buffer */
+	__u32 height;	/* height of entire buffer */
+	struct mxcfb_rect alt_update_region;	/* region within buffer to update */
+};
+
+struct mxcfb_update_data_org {
+	struct mxcfb_rect update_region;
+	__u32 waveform_mode;
+	__u32 update_mode;
+	__u32 update_marker;
+	int temp;
+	unsigned int flags;
+	int dither_mode;
+	int quant_bit;
+	struct mxcfb_alt_buffer_data_org alt_buffer_data;
+}; // end of new stuff
+
+struct mxcfb_update_marker_data {
+	__u32 update_marker;
+	__u32 collision_test;
+};
+
+/*
+ * Structure used to define waveform modes for driver
+ * Needed for driver to perform auto-waveform selection
+ */
+struct mxcfb_waveform_modes {
+	// common
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc32;
+
+	// 2013+
+	int mode_gl16;
+	int mode_a2;
+	int mode_aa;    // was mode_reagl on Cervantes 2013/Fnac Touch Light
+	int mode_aad;   // was mode_reagld on Cervantes 2013/Fnac Touch Light
+};
+
+/*
+ * Structure used to define a 5*3 matrix of parameters for
+ * setting IPU DP CSC module related to this framebuffer.
+ */
+struct mxcfb_csc_matrix {
+	int param[5][3];
+};
+
+#define MXCFB_WAIT_FOR_VSYNC	    	_IOW('F', 0x20, u_int32_t)
+#define MXCFB_SET_GBL_ALPHA         	_IOW('F', 0x21, struct mxcfb_gbl_alpha)
+#define MXCFB_SET_CLR_KEY           	_IOW('F', 0x22, struct mxcfb_color_key)
+#define MXCFB_SET_OVERLAY_POS       	_IOWR('F', 0x24, struct mxcfb_pos)
+#define MXCFB_GET_FB_IPU_CHAN 	    	_IOR('F', 0x25, u_int32_t)
+#define MXCFB_SET_LOC_ALPHA         	_IOWR('F', 0x26, struct mxcfb_loc_alpha)
+#define MXCFB_SET_LOC_ALP_BUF       	_IOW('F', 0x27, unsigned long)
+#define MXCFB_SET_GAMMA	            	_IOW('F', 0x28, struct mxcfb_gamma)
+#define MXCFB_GET_FB_IPU_DI 	    	_IOR('F', 0x29, u_int32_t)
+#define MXCFB_GET_DIFMT	           	_IOR('F', 0x2A, u_int32_t)
+#define MXCFB_GET_FB_BLANK          	_IOR('F', 0x2B, u_int32_t)
+#define MXCFB_SET_DIFMT		        _IOW('F', 0x2C, u_int32_t)
+#define MXCFB_ENABLE_VSYNC_EVENT	_IOW('F', 0x33, int32_t)
+#define MXCFB_CSC_UPDATE	        _IOW('F', 0x2D, struct mxcfb_csc_matrix)
+
+/* IOCTLs for E-ink panel updates */
+#define MXCFB_SET_WAVEFORM_MODES	_IOW('F', 0x2B, struct mxcfb_waveform_modes)
+#define MXCFB_SET_TEMPERATURE		_IOW('F', 0x2C, int32_t)
+#define MXCFB_SET_AUTO_UPDATE_MODE	_IOW('F', 0x2D, __u32)
+#define MXCFB_SEND_UPDATE		_IOW('F', 0x2E, struct mxcfb_update_data)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE	_IOW('F', 0x2F, __u32)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE2 _IOWR('F', 0x35, struct mxcfb_update_marker_data)
+#define MXCFB_SET_PWRDOWN_DELAY		_IOW('F', 0x30, int32_t)
+#define MXCFB_GET_PWRDOWN_DELAY		_IOR('F', 0x31, int32_t)
+#define MXCFB_SET_UPDATE_SCHEME		_IOW('F', 0x32, __u32)
+#define MXCFB_GET_WORK_BUFFER		_IOWR('F', 0x34, unsigned long)
+
+// cervantes 4 stuff
+#define MXCFB_SEND_UPDATE_ORG		_IOW('F', 0x2E, struct mxcfb_update_data_org)
+
+
+#ifdef __KERNEL__
+
+extern struct fb_videomode mxcfb_modedb[];
+extern int mxcfb_modedb_sz;
+
+enum {
+	MXC_DISP_SPEC_DEV = 0,
+	MXC_DISP_DDC_DEV = 1,
+};
+
+enum {
+	MXCFB_REFRESH_OFF,
+	MXCFB_REFRESH_AUTO,
+	MXCFB_REFRESH_PARTIAL,
+};
+
+int mxcfb_set_refresh_mode(struct fb_info *fbi, int mode,
+			   struct mxcfb_rect *update_region);
+int mxc_elcdif_frame_addr_setup(dma_addr_t phys);
+void mxcfb_elcdif_register_mode(const struct fb_videomode *modedb,
+		int num_modes, int dev_mode);
+
+#endif				/* __KERNEL__ */
+#endif

--- a/fbink.c
+++ b/fbink.c
@@ -960,7 +960,7 @@ static long int
 }
 
 // Handle the various eInk update API quirks for the full range of HW we support...
-#ifdef FBINK_FOR_KINDLE
+#if defined (FBINK_FOR_KINDLE)
 // Legacy Kindle devices ([K2<->K4])
 static int
     refresh_legacy(int fbfd, const struct mxcfb_rect region, bool is_flashing)
@@ -1140,7 +1140,118 @@ static int
 
 	return EXIT_SUCCESS;
 }
+#elif defined (FBINK_FOR_CERVANTES)
+// Legacy Cervantes devices (2013)
+static int
+    refresh_cervantes(int fbfd, const struct mxcfb_rect region, uint32_t waveform_mode, uint32_t update_mode, uint32_t marker)
+{
+	struct mxcfb_update_data update = {
+		.update_region = region,
+		.waveform_mode = waveform_mode,
+		.update_mode   = update_mode,
+		.update_marker = marker,
+		.temp          = TEMP_USE_AMBIENT,
+		.flags         = (waveform_mode == WAVEFORM_MODE_REAGLD)
+			     ? EPDC_FLAG_USE_AAD
+			     : (waveform_mode == WAVEFORM_MODE_A2) ? EPDC_FLAG_FORCE_MONOCHROME : 0U,
+		.alt_buffer_data = { 0U },
+	};
 
+	int rv;
+	rv = ioctl(fbfd, MXCFB_SEND_UPDATE, &update);
+
+	if (rv < 0) {
+		char  buf[256];
+		char* errstr = strerror_r(errno, buf, sizeof(buf));
+		fprintf(stderr, "[FBInk] MXCFB_SEND_UPDATE: %s\n", errstr);
+		if (errno == EINVAL) {
+			fprintf(stderr,
+				"[FBInk] update_region={top=%u, left=%u, width=%u, height=%u}\n",
+				region.top,
+				region.left,
+				region.width,
+				region.height);
+		}
+		return ERRCODE(EXIT_FAILURE);
+	}
+
+	if (update_mode == UPDATE_MODE_FULL) {
+		rv = ioctl(fbfd, MXCFB_WAIT_FOR_UPDATE_COMPLETE, &marker);
+
+		if (rv < 0) {
+			char  buf[256];
+			char* errstr = strerror_r(errno, buf, sizeof(buf));
+			fprintf(stderr, "[FBInk] MXCFB_WAIT_FOR_UPDATE_COMPLETE: %s\n", errstr);
+			return ERRCODE(EXIT_FAILURE);
+		} else {
+			// NOTE: Timeout is set to 10000ms
+			LOG("Waited %ldms for completion of flashing update %u", (10000 - jiffies_to_ms(rv)), marker);
+		}
+	}
+
+	return EXIT_SUCCESS;
+}
+
+// New cervantes devices (2013+)
+static int
+    refresh_cervantes_new(int                     fbfd,
+		     const struct mxcfb_rect region,
+		     uint32_t                waveform_mode,
+		     uint32_t                update_mode,
+		     uint32_t                marker)
+{
+	struct mxcfb_update_data_org update = {
+		.update_region = region,
+		.waveform_mode = waveform_mode,
+		.update_mode   = update_mode,
+		.update_marker = marker,
+		.temp          = TEMP_USE_AMBIENT,
+		.flags         = (waveform_mode == WAVEFORM_MODE_GLD16)
+			     ? EPDC_FLAG_USE_REGAL
+			     : (waveform_mode == WAVEFORM_MODE_A2) ? EPDC_FLAG_FORCE_MONOCHROME : 0U,
+		.dither_mode     = EPDC_FLAG_USE_DITHERING_PASSTHROUGH,
+		.quant_bit       = 0,
+		.alt_buffer_data = { 0U },
+	};
+
+	int rv;
+	rv = ioctl(fbfd, MXCFB_SEND_UPDATE, &update);
+
+	if (rv < 0) {
+		char  buf[256];
+		char* errstr = strerror_r(errno, buf, sizeof(buf));
+		fprintf(stderr, "[FBInk] MXCFB_SEND_UPDATE: %s\n", errstr);
+		if (errno == EINVAL) {
+			fprintf(stderr,
+				"[FBInk] update_region={top=%u, left=%u, width=%u, height=%u}\n",
+				region.top,
+				region.left,
+				region.width,
+				region.height);
+		}
+		return ERRCODE(EXIT_FAILURE);
+	}
+
+	if (update_mode == UPDATE_MODE_FULL) {
+		struct mxcfb_update_marker_data update_marker = {
+			.update_marker  = marker,
+			.collision_test = 0U,
+		};
+
+		rv = ioctl(fbfd, MXCFB_WAIT_FOR_UPDATE_COMPLETE2, &update_marker);
+
+		if (rv < 0) {
+			char  buf[256];
+			char* errstr = strerror_r(errno, buf, sizeof(buf));
+			fprintf(stderr, "[FBInk] MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3: %s\n", errstr);
+			return ERRCODE(EXIT_FAILURE);
+		} else {
+			// NOTE: Timeout is set to 5000ms
+			LOG("Waited %ldms for completion of flashing update %u", (5000 - jiffies_to_ms(rv)), marker);
+		}
+	}
+	return EXIT_SUCCESS;
+}
 #else
 // Kobo devices ([Mk3<->Mk6])
 static int
@@ -1301,11 +1412,17 @@ static int
 		marker = (70U + 66U + 73U + 78U + 75U);
 	}
 
-#ifdef FBINK_FOR_KINDLE
+#if defined(FBINK_FOR_KINDLE)
 	if (deviceQuirks.isKindleOasis2) {
 		return refresh_kindle_koa2(fbfd, region, wfm, upm, marker);
 	} else {
 		return refresh_kindle(fbfd, region, wfm, upm, marker);
+	}
+#elif defined(FBINK_FOR_CERVANTES)
+	if (deviceQuirks.isCervantesNew) {
+		return refresh_cervantes_new(fbfd, region, wfm, upm, marker);
+	} else {
+		return refresh_cervantes(fbfd, region, wfm, upm, marker);
 	}
 #else
 	if (deviceQuirks.isKoboMk7) {

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -20,7 +20,7 @@
 
 #include "fbink_device_id.h"
 
-#ifdef FBINK_FOR_KINDLE
+#if defined (FBINK_FOR_KINDLE)
 // NOTE: This is adapted from KindleTool,
 //       c.f., https://github.com/NiLuJe/KindleTool/blob/master/KindleTool/kindle_tool.h#L189
 static bool
@@ -202,6 +202,57 @@ static void
 		}
 	}
 }
+#elif defined (FBINK_FOR_CERVANTES)
+// read pcb id from HWCONFIG for bq/fnac devices, adapted from OKreader's kobo_hwconfig:
+// https://github.com/lgeek/okreader/blob/master/src/kobo_hwconfig/kobo_hwconfig.c
+static void
+    identify_cervantes(FBInkDeviceQuirks* device_quirks)
+{
+	FILE* fp = fopen(HWCONFIG_DEVICE, "rb");
+	if (!fp) {
+		fprintf(stderr, "[FBInk] Couldn't read from %s (not running on a Cervantes?)!\n", HWCONFIG_DEVICE);
+	} else {
+		int ret;
+		hwconfig config;
+
+		ret = fseek(fp, HWCONFIG_OFFSET, SEEK_SET);
+		if (ret != 0)
+		{
+			fprintf(stderr, "[FBInk] Failed to seek to position 0x%p in %s\n", (void*) HWCONFIG_OFFSET, HWCONFIG_DEVICE);
+			exit(EXIT_FAILURE);
+		}
+
+		ret = (int) fread(&config, sizeof(config), 1, fp);
+		if (ret != 1)
+		{
+			fprintf(stderr, "[FBInk] Failed to read the HWCONFIG entry in %s\n", HWCONFIG_DEVICE);
+			exit(EXIT_FAILURE);
+		}
+
+		if (strncmp(config.magic, HWCONFIG_MAGIC, strlen(HWCONFIG_MAGIC)) != 0)
+		{
+			fprintf(stderr, "[FBInk] Input file %s does not appear to contain a HWCONFIG entry\n", HWCONFIG_DEVICE);
+			exit(EXIT_FAILURE);
+		}
+
+                // supported devices,
+                // from https://github.com/bq/cervantes/blob/master/bqHAL/Devices/mx508/src/DeviceInfoMx508.cpp#L33-L37
+		switch(config.pcb_id) {
+			case 22: // BQ Cervantes Touch - Fnac Touch (2012-2013)
+			case 23: // BQ Cervantes TouchLight - Fnac Touch Plus (2012-2013)
+			case 33: // BQ Cervantes 2013 - Fnac Touch Light (2013)
+				break;
+			case 51: // BQ Cervantes 3 - Fnac Touch Light 2 (2016)
+			case 68: // BQ Cervantes 4
+				device_quirks->isCervantesNew = true;
+				break;
+			default:
+				fprintf(stderr, "[FBInk] Unidentified Cervantes device (%d)!\n", config.pcb_id);
+				break;
+		}
+		fclose(fp);
+	}
+}
 #else
 // NOTE: This is lifted from FBGrab,
 //       c.f., http://trac.ak-team.com/trac/browser/niluje/Configs/trunk/Kindle/Misc/FBGrab/fbgrab.c#L808
@@ -275,8 +326,10 @@ static void
 static void
     identify_device(FBInkDeviceQuirks* device_quirks)
 {
-#ifdef FBINK_FOR_KINDLE
+#if defined (FBINK_FOR_KINDLE)
 	identify_kindle(device_quirks);
+#elif defined (FBINK_FOR_CERVANTES)
+        identify_cervantes(device_quirks);
 #else
 	identify_kobo(device_quirks);
 #endif

--- a/fbink_device_id.h
+++ b/fbink_device_id.h
@@ -32,6 +32,17 @@ static bool     is_kindle_device(uint32_t, FBInkDeviceQuirks*);
 static bool     is_kindle_device_new(uint32_t, FBInkDeviceQuirks*);
 static uint32_t from_base(char*, uint8_t);
 static void     identify_kindle(FBInkDeviceQuirks*);
+#elif defined (FBINK_FOR_CERVANTES)
+#define HWCONFIG_DEVICE "/dev/mmcblk0"
+#define HWCONFIG_OFFSET (1024 * 512)
+#define HWCONFIG_MAGIC  "HW CONFIG "
+typedef struct  __attribute__ ((__packed__)) {
+	char    magic[10];
+	char    version[5];
+	uint8_t size;
+	uint8_t pcb_id;
+} hwconfig;
+static void identify_cervantes(FBInkDeviceQuirks*);
 #else
 static void identify_kobo(FBInkDeviceQuirks*);
 #endif

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -84,10 +84,12 @@
 #include "utf8/utf8.h"
 
 // NOTE: We always neeed one of those, because we rely on mxcfb_rect in a number of places
-#ifdef FBINK_FOR_KINDLE
+#if defined (FBINK_FOR_KINDLE)
 #	include "eink/mxcfb-kindle.h"
 // Legacy einkfb driver
 #	include "eink/einkfb.h"
+#elif defined (FBINK_FOR_CERVANTES)
+#       include "eink/mxcfb-cervantes.h"
 #else
 #	include "eink/mxcfb-kobo.h"
 #endif
@@ -289,10 +291,13 @@ static struct mxcfb_rect draw(const char*,
 			      const FBInkConfig*);
 
 static long int jiffies_to_ms(long int);
-#ifdef FBINK_FOR_KINDLE
+#if defined (FBINK_FOR_KINDLE)
 static int refresh_legacy(int, const struct mxcfb_rect, bool);
 static int refresh_kindle(int, const struct mxcfb_rect, uint32_t, uint32_t, uint32_t);
 static int refresh_kindle_koa2(int, const struct mxcfb_rect, uint32_t, uint32_t, uint32_t);
+#elif defined (FBINK_FOR_CERVANTES)
+static int refresh_cervantes(int, const struct mxcfb_rect, uint32_t, uint32_t, uint32_t);
+static int refresh_cervantes_new(int, const struct mxcfb_rect, uint32_t, uint32_t, uint32_t);
 #else
 static int refresh_kobo(int, const struct mxcfb_rect, uint32_t, uint32_t, uint32_t);
 static int refresh_kobo_mk7(int, const struct mxcfb_rect, uint32_t, uint32_t, uint32_t);

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -34,6 +34,7 @@ typedef struct
 	bool   isKoboNonMT;
 	bool   isKobo16Landscape;
 	bool   isKoboMk7;
+	bool   isCervantesNew;
 	int8_t koboVertOffset;
 	bool   skipId;
 } FBInkDeviceQuirks;


### PR DESCRIPTION
add support for bq cervantes and fnac touchlight devices (a list of devices on https://blog.bq.com/es/bq-ereaders-developers-program/)