### PR TITLE
[WIP] OpenType Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "stb"]
 	path = stb
 	url = https://github.com/nothings/stb.git
+[submodule "libunibreak"]
+	path = libunibreak
+	url = https://github.com/adah1972/libunibreak

--- a/CREDITS
+++ b/CREDITS
@@ -8,10 +8,13 @@ This project makes use of a number of third-party libraries, which we'll acknowl
 		Released into the public domain.
 		(https://www.cprogramming.com/tutorial/unicode.html)
 
-	* stb_image (Image loader), by Sean Barrett,
+	* stb_image (Image loader) and stb_truetype (font renderer), by Sean Barrett,
 		Released into the public domain.
 		(http://nothings.org/stb)
 
+	* libunibreak (Unicode line breaking implementation) by Wu Yongwei, et al
+		Licensed under the Zlib license
+		(https://github.com/adah1972/libunibreak)
 
 As well as a number of third-party resources (namely, font files):
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 	RANLIB?=gcc-ranlib
 endif
 
-DEBUG_CFLAGS=-O0 -fno-omit-frame-pointer -pipe -g
+DEBUG_CFLAGS=-Og -fno-omit-frame-pointer -pipe -g
 # Fallback CFLAGS, we honor the env first and foremost!
 OPT_CFLAGS=-O2 -fomit-frame-pointer -pipe
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 	RANLIB?=gcc-ranlib
 endif
 
-DEBUG_CFLAGS=-Og -fno-omit-frame-pointer -pipe -g
+DEBUG_CFLAGS=-O0 -fno-omit-frame-pointer -pipe -g
 # Fallback CFLAGS, we honor the env first and foremost!
 OPT_CFLAGS=-O2 -fomit-frame-pointer -pipe
 
@@ -179,10 +179,16 @@ ifdef MATHS
 	EXTRA_CPPFLAGS+=-DFBINK_WITH_MATHS
 	LIBS+=-lm
 endif
-
+ifndef MINIMAL
+	LIBS+=-lm
+endif
 ##
 # Now that we're done fiddling with flags, let's build stuff!
-LIB_SRCS=fbink.c utf8/utf8.c
+ifdef MINIMAL
+	LIB_SRCS=fbink.c utf8/utf8.c
+else
+	LIB_SRCS=fbink.c utf8/utf8.c libunibreak/src/linebreak.c libunibreak/src/linebreakdata.c libunibreak/src/unibreakdef.c libunibreak/src/linebreakdef.c
+endif
 CMD_SRCS=fbink_cmd.c
 BTN_SRCS=button_scan_cmd.c
 # Unless we're asking for a minimal build, include the Unscii fonts, too
@@ -191,6 +197,7 @@ ifdef MINIMAL
 else
 	EXTRA_CPPFLAGS+=-DFBINK_WITH_FONTS
 	EXTRA_CPPFLAGS+=-DFBINK_WITH_IMAGE
+	EXTRA_CPPFLAGS+=-DFBINK_WITH_OPENTYPE
 	# Connect button scanning is Kobo specific
 	ifndef KINDLE
 		ifndef CERVANTES
@@ -235,7 +242,7 @@ $(OUT_DIR)/%.o: %.c
 	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) -o $@ -c $<
 
 outdir:
-	mkdir -p $(OUT_DIR)/shared/utf8 $(OUT_DIR)/static/utf8
+	mkdir -p $(OUT_DIR)/shared/utf8 $(OUT_DIR)/static/utf8 $(OUT_DIR)/shared/libunibreak/src $(OUT_DIR)/static/libunibreak/src
 
 all: outdir static
 
@@ -348,8 +355,10 @@ clean:
 	rm -rf Release/*.so*
 	rm -rf Release/shared/*.o
 	rm -rf Release/shared/utf8/*.o
+	rm -rf Release/shared/libunibreak/src/*.o
 	rm -rf Release/static/*.o
 	rm -rf Release/static/utf8/*.o
+	rm -rf Release/static/libunibreak/src/*.o
 	rm -rf Release/*.o
 	rm -rf Release/fbink
 	rm -rf Release/button_scan

--- a/Makefile
+++ b/Makefile
@@ -366,8 +366,10 @@ clean:
 	rm -rf Debug/*.so*
 	rm -rf Debug/shared/*.o
 	rm -rf Debug/shared/utf8/*.o
+	rm -rf Debug/shared/libunibreak/src/*.o
 	rm -rf Debug/static/*.o
 	rm -rf Debug/static/utf8/*.o
+	rm -rf Debug/static/libunibreak/src/*.o
 	rm -rf Debug/*.o
 	rm -rf Debug/fbink
 	rm -rf Debug/button_scan

--- a/fbink.c
+++ b/fbink.c
@@ -3162,6 +3162,32 @@ int
 	if (!complete_str) {
 		ELOG("[FBInk] String too long. Truncated to %u characters", (c_index + 1));
 	}
+	// Let's determine our exact height, so we can determine vertical alignment later if required.
+	printf("Maximum printable height is %u\n", print_height);
+	unsigned int curr_print_height = 0;
+	for (line = 0; line < num_lines; line++) {
+		if (!lines[line].line_used) {
+			break;
+		}
+		if (curr_print_height + max_line_height > print_height) {
+			// This line can't be printed, so set it to unused
+			lines[line].line_used = false;
+			break;
+		}
+		curr_print_height += max_line_height;
+		if (line <= num_lines - 1) {
+			if (line == num_lines - 1 || !lines[line + 1].line_used) {
+				// Last line, we don't want to add a line gap
+				break;
+			}
+		}
+		// We only add a line gap if there's room for one
+		if (!(curr_print_height + lines[line].line_gap > print_height)) {
+			curr_print_height += lines[line].line_gap;
+		}
+	}
+	printf("Actual print height is %u\n", curr_print_height);
+
 	// Hopefully, we have some lines to render!
 
 	// Create a bitmap buffer to render a single line. We don't render the glyphs directly to the

--- a/fbink.c
+++ b/fbink.c
@@ -2061,6 +2061,7 @@ int
 	if (!stbtt_InitFont(&otFontInfo, font_data, 0)) {
 		rv = ERRCODE(EXIT_FAILURE);
 	}
+	otInit = true;
 	return rv;
 #else
 	fprintf(stderr, "[FBInk] Opentype support is disabled in this FBInk build!\n");
@@ -2641,6 +2642,12 @@ int
 		//Note, we do a lot of casting floats to ints, so silence those GCC warnings
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wfloat-conversion"
+
+	// Has fbink_init_ot() been called yet?
+	if (!otInit) {
+		return ERRCODE(ENODATA);
+	}
+
 	// If we open a fd now, we'll only keep it open for this single print call!
 	// NOTE: We *expect* to be initialized at this point, though, but that's on the caller's hands!
 	bool keep_fd = true;

--- a/fbink.c
+++ b/fbink.c
@@ -3383,16 +3383,32 @@ int
 		start_x = paint_point.x;
 		start_y = paint_point.y;
 		lnPtr = line_buff;
-		for (int j = 0; j < font_size_px; j++) {
-			for (int k = 0; k < lw; k++) {
-				color.r = color.b = color.g = lnPtr[k] ^ invert;
-				put_pixel(&paint_point, &color);
-				paint_point.x++;
+		// Normal painting to framebuffer. Please forgive the code repetition. Performance...
+		if (!is_overlay && !is_fgless && !is_bgless) {
+			for (int j = 0; j < font_size_px; j++) {
+				for (int k = 0; k < lw; k++) {
+					color.r = color.b = color.g = lnPtr[k] ^ invert;
+					put_pixel(&paint_point, &color);
+					paint_point.x++;
+				}
+				lnPtr += max_lw;
+				paint_point.x = start_x;
+				paint_point.y++;
 			}
-			lnPtr += max_lw;
-			paint_point.x = start_x;
-			paint_point.y++;
-		}
+		} else if (is_fgless) {
+			for (int j = 0; j < font_size_px; j++) {
+				for (int k = 0; k < lw; k++) {
+					if (lnPtr[k] == bgcolor) {
+						color.r = color.b = color.g = lnPtr[k] ^ invert;
+						put_pixel(&paint_point, &color);
+					}
+					paint_point.x++;
+				}
+				lnPtr += max_lw;
+				paint_point.x = start_x;
+				paint_point.y++;
+			}
+		} 
 		paint_point.y += (unsigned short int)lines[line].line_gap;
 		paint_point.x = area.tl.x;
 		if (paint_point.y + max_line_height > area.br.y) {

--- a/fbink.c
+++ b/fbink.c
@@ -2801,6 +2801,7 @@ int
 	if (!line_buff || !glyph_buff) {
 		goto cleanup;
 	}
+	// Setup the variables needed to render
 	FBInkCoordinates curr_point = { 0, baseline };
 	FBInkCoordinates ins_point = {0, baseline};
 	FBInkCoordinates paint_point = {area.tl.x, area.tl.y};
@@ -2808,6 +2809,7 @@ int
 	uint32_t tmp_c;
 	unsigned char *lnPtr, *glPtr = NULL;
 	unsigned short start_x, start_y;
+	// Render!
 	for (line = 0; lines[line].line_used; line++) {
 		printf("Line # %d\n", line);
 		lw = 0;

--- a/fbink.c
+++ b/fbink.c
@@ -3299,12 +3299,14 @@ int
 			// Ensure that our glyph size does not exceed the buffer size. Resize the buffer if it does
 			if (gw * gh > (int)glyph_buffer_dims) {
 				unsigned int new_buff_size = (unsigned int)gw * (unsigned int)gh * 2U * sizeof(unsigned char);
-				glyph_buff = realloc(glyph_buff, new_buff_size);
-				if (!glyph_buff) {
+				unsigned char tmp_g_buff = NULL;
+				tmp_g_buff = realloc(glyph_buff, new_buff_size);
+				if (!tmp_g_buff) {
 					ELOG("[FBInk] Failure resizing glyph buffer");
 					ERRCODE(EXIT_FAILURE);
 					goto cleanup;
 				}
+				glyph_buff = tmp_g_buff;
 				glyph_buffer_dims = new_buff_size;
 			}
 			// Make sure we don't have an underflow/wrap around

--- a/fbink.c
+++ b/fbink.c
@@ -2743,7 +2743,7 @@ int
 		while (c_index < chars_in_str) {
 			// First, we check for a mandatory break
 			if (brk_buff[c_index] == LINEBREAK_MUSTBREAK) {
-				unsigned char last_index;
+				unsigned char last_index = c_index;
 				// We don't want to print the break character
 				u8_dec(string, &last_index);
 				lines[line].endCharIndex = last_index;

--- a/fbink.c
+++ b/fbink.c
@@ -3071,7 +3071,7 @@ int
 			// stb_truetype does not appear to create a bounding box for space characters,
 			// so we need to handle this situation.
 			if (!gw && adv) {
-				lw = curr_x + (int)roundf(sf * adv);
+				lw = curr_x;
 			} else {
 				lw = curr_x + x0 + gw;
 			}
@@ -3205,10 +3205,12 @@ int
 			gh = y1 - y0;
 			ins_point.x = curr_point.x + x0;
 			ins_point.y += y0;
-			if (!gw && adv) {
-				lw = curr_point.x + (int)roundf(sf * adv);
-			} else {
+			// We only increase the lw if glyph not a space This hopefully prevent trailing
+			// spaces from being printed on a line.
+			if (gw) {
 				lw = ins_point.x + gw;
+			} else {
+				lw = ins_point.x;
 			}
 			printf("Current Rendered LW: %d  Line# %d\n", lw, line);
 			// Just in case our arithmetic was off by a pixel or two...

--- a/fbink.c
+++ b/fbink.c
@@ -3036,9 +3036,11 @@ int
 			int gw_from_origin = x1;
 			printf("GW: %d\n", (x1 - x0));
 			printf("Calced LW: %d\n", (curr_x + gw_from_origin));
+
 			// Oops, we appear to have advanced too far :)
 			// Better backtrack to see if we can find a suitable break opportunity
-			if (curr_x + gw_from_origin > max_lw) {
+			unsigned short ot_meas_padding = 3; // Just so we don't use a magic number
+			if (curr_x + gw_from_origin > (max_lw - ot_meas_padding)) {
 				// Set our final line character to the previous char in case we cannot
 				// find a suitable breakpoint
 				u8_dec(string, &c_index);
@@ -3147,8 +3149,13 @@ int
 			ins_point.y += y0;
 			lw = ins_point.x + gw;
 			// Just in case our arithmetic was off by a pixel or two...
+			// Note that we are deliberately using a slightly shorter line
+			// width during the measurement phase, so this should not happen.
+			// If it does occur, we will now exit instead of clipping the glyph
+			// bounding box, to avoid the possiblity of stb_truetype segfaulting.
 			if (lw > max_lw) {
-				gw -= lw - max_lw;
+				rv = ERRCODE(EXIT_FAILURE);
+				goto cleanup;
 			}
 			// Because the stbtt_MakeCodepointBitmap documentation is a bit vague on this
 			// point, the parameter 'out_stride' should be the width of the surface in our

--- a/fbink.c
+++ b/fbink.c
@@ -2063,8 +2063,9 @@ int
 	}
 	return rv;
 #else
-	return ERRCODE(ENOTSUP);
-#endif
+	fprintf(stderr, "[FBInk] Opentype support is disabled in this FBInk build!\n");
+	return ERRCODE(ENOSYS);
+#endif // FBINK_WITH_OPENTYPE
 }
 
 // Dump a few of our internal state variables to stdout, for shell script consumption
@@ -2908,8 +2909,9 @@ int
 	return rv;
 #	pragma GCC diagnostic pop
 #else
-	return ERRCODE(ENOTSUP);
-#endif
+	fprintf(stderr, "[FBInk] Opentype support is disabled in this FBInk build!\n");
+	return ERRCODE(ENOSYS);
+#endif // FBINK_WITH_OPENTYPE
 }
 
 // Small public wrapper around refresh(), without the caller having to depend on mxcfb headers

--- a/fbink.c
+++ b/fbink.c
@@ -2961,7 +2961,7 @@ int
 	// Calculate the maximum number of lines we may have to deal with
 	unsigned int print_height = area.br.y - area.tl.y;
 	unsigned int num_lines = print_height / max_font_height;
-	
+
 	// And allocate the memory for it...
 	lines = calloc(num_lines, sizeof(FBInkOTLine));
 
@@ -2969,7 +2969,7 @@ int
 
 	// Note: we only care about the byte length here
 	size_t str_len_bytes = strlen(string);
-	brk_buff = calloc(str_len_bytes + 1, sizeof(char));
+	brk_buff = calloc(str_len_bytes + 1, sizeof(*brk_buff));
 	if (!brk_buff) {
 		ELOG("[FBInk] Linebreak buffer could not be allocated");
 		rv = ERRCODE(EXIT_FAILURE);
@@ -2982,7 +2982,7 @@ int
 
 	// Parse our string for formatting, if requested
 	if (cfg->is_formatted) {
-		fmt_buff = calloc(str_len_bytes + 1, sizeof(unsigned char));
+		fmt_buff = calloc(str_len_bytes + 1, sizeof(*fmt_buff));
 		if (!fmt_buff) {
 			ELOG("[FBInk] Formatted text buffer could not be allocated");
 			rv = ERRCODE(EXIT_FAILURE);
@@ -3060,7 +3060,7 @@ int
 			// Note, these metrics are unscaled, we need to use our previously
 			// obtained scale factor (sf) to get the metrics as pixels
 			stbtt_GetCodepointHMetrics(curr_font, (int)c, &adv, &lsb);
-			
+
 			// If starting a line with a character that has a negative lsb
 			// eg 'j', move our start point a little.
 			if (curr_x == 0 && lsb < 0) {
@@ -3140,9 +3140,9 @@ int
 	// Create a bitmap buffer to render a single line. We don't render the glyphs directly to the
 	// fb here, as we need to do some simple blending, and it makes it easier to calculate our
 	// centering if required.
-	line_buff = calloc(max_lw * font_size_px, sizeof(unsigned char));
+	line_buff = calloc(max_lw * font_size_px, sizeof(*line_buff));
 	// We also don't want to be creating a new buffer for every glyph
-	glyph_buff = calloc(font_size_px * font_size_px * 8, sizeof(unsigned char));
+	glyph_buff = calloc(font_size_px * font_size_px * 8, sizeof(*glyph_buff));
 	if (!line_buff || !glyph_buff) {
 		ELOG("[FBInk] Line or glyph buffers could not be allocated");
 		rv = ERRCODE(EXIT_FAILURE);
@@ -3212,7 +3212,7 @@ int
 			}
 			ins_point.x = curr_point.x + x0;
 			ins_point.y += y0;
-			printf("gw: %d & gh: %d for c: U+%04X @ ins_point (%hu, %hu) & curr_point (%hu, %hu) / x0: %d y0: %d x1: %d y1: %d\n", gw, gh, c, ins_point.x, ins_point.y, curr_point.x, curr_point.y, x0, y0, x1, y1);
+			printf("gw: %d & gh: %d for c: U+%04X @ ins_point (%hu, %hu) & curr_point (%hu, %hu) / x0: %d y0: %d x1: %d y1: %d / lsb: %d\n", gw, gh, c, ins_point.x, ins_point.y, curr_point.x, curr_point.y, x0, y0, x1, y1, lsb);
 			// We only increase the lw if glyph not a space This hopefully prevent trailing
 			// spaces from being printed on a line.
 			if (gw > 0) {

--- a/fbink.c
+++ b/fbink.c
@@ -2859,89 +2859,104 @@ int
 	// character in the loop, as needed.
 	stbtt_fontinfo *curr_font = NULL;
 
-	// A struct to hold some metrics for each font as a whole
-	struct font_v_metrics {
-		float sf;
-		int asc;
-		int desc;
-		int lg;
-		int baseline;
-	};
-	int max_font_height = 0;
+	int max_row_height = 0;
 	// Calculate some metrics for every font we have loaded.
 	// Please forgive the repetition here.
 
 	// Declaring these three variables early, so a default can be set
 	float sf = 0.0;
-	int baseline = 0;
-	int lg = 0;
-	struct font_v_metrics rgMetrics, itMetrics, bdMetrics, bditMetrics;
+	int max_baseline = 0;
+	int max_lg = 0;
+	int max_desc = 0;
+	float rgSF, itSF, bdSF, bditSF;
+	int asc, desc, lg;
+	int scaled_bl, scaled_desc, scaled_lg;
 	if (otFonts.otRegular) {
-		rgMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otRegular, (float)font_size_px);
-		stbtt_GetFontVMetrics(otFonts.otRegular, &rgMetrics.asc, &rgMetrics.desc, &rgMetrics.lg);
-		rgMetrics.baseline = (int) lroundf(rgMetrics.sf * rgMetrics.asc);
-		int height = (int) lroundf(rgMetrics.sf * (rgMetrics.asc - rgMetrics.desc + rgMetrics.lg));
-		if (height > max_font_height) {
-			max_font_height = height;
+		rgSF = stbtt_ScaleForPixelHeight(otFonts.otRegular, (float)font_size_px);
+		stbtt_GetFontVMetrics(otFonts.otRegular, &asc, &desc, &lg);
+		scaled_bl = (int)(ceilf(rgSF * asc));
+		scaled_desc = (int)(ceilf(rgSF * desc));
+		scaled_lg = (int)(ceilf(rgSF * lg));
+		if (scaled_bl > max_baseline) {
+			max_baseline = scaled_bl;
+		}
+		if (scaled_desc < max_desc) {
+			max_desc = scaled_desc;
+		}
+		if (scaled_lg > max_lg) {
+			max_lg = scaled_lg;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
 			curr_font = otFonts.otRegular;
-			sf = rgMetrics.sf;
-			baseline = rgMetrics.baseline;
-			lg = rgMetrics.lg;
+			sf = rgSF;
 			ELOG("[FBInk] Unformatted text defaulting to regular font");
 		}
 	}
 	if (otFonts.otItalic) {
-		itMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otItalic, (float)font_size_px);
-		stbtt_GetFontVMetrics(otFonts.otRegular, &itMetrics.asc, &itMetrics.desc, &itMetrics.lg);
-		itMetrics.baseline = (int) lroundf(itMetrics.sf * itMetrics.asc);
-		int height = (int) lroundf(itMetrics.sf * (itMetrics.asc - itMetrics.desc + itMetrics.lg));
-		if (height > max_font_height) {
-			max_font_height = height;
+		itSF = stbtt_ScaleForPixelHeight(otFonts.otItalic, (float)font_size_px);
+		stbtt_GetFontVMetrics(otFonts.otItalic, &asc, &desc, &lg);
+		scaled_bl = (int)(ceilf(itSF * asc));
+		scaled_desc = (int)(ceilf(itSF * desc));
+		scaled_lg = (int)(ceilf(itSF * lg));
+		if (scaled_bl > max_baseline) {
+			max_baseline = scaled_bl;
+		}
+		if (scaled_desc < max_desc) {
+			max_desc = scaled_desc;
+		}
+		if (scaled_lg > max_lg) {
+			max_lg = scaled_lg;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
 			curr_font = otFonts.otItalic;
-			sf = itMetrics.sf;
-			baseline = itMetrics.baseline;
-			lg = itMetrics.lg;
+			sf = itSF;
 			ELOG("[FBInk] Unformatted text defaulting to italic font");
 		}
 	}
 	if (otFonts.otBold) {
-		bdMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otBold, (float)font_size_px);
-		stbtt_GetFontVMetrics(otFonts.otRegular, &bdMetrics.asc, &bdMetrics.desc, &bdMetrics.lg);
-		bdMetrics.baseline = (int)lroundf(bdMetrics.sf * bdMetrics.asc);
-		int height = (int)lroundf(bdMetrics.sf * (bdMetrics.asc - bdMetrics.desc + bdMetrics.lg));
-		if (height > max_font_height) {
-			max_font_height = height;
+		bdSF = stbtt_ScaleForPixelHeight(otFonts.otBold, (float)font_size_px);
+		stbtt_GetFontVMetrics(otFonts.otBold, &asc, &desc, &lg);
+		scaled_bl = (int)(ceilf(bdSF * asc));
+		scaled_desc = (int)(ceilf(bdSF * desc));
+		scaled_lg = (int)(ceilf(bdSF * lg));
+		if (scaled_bl > max_baseline) {
+			max_baseline = scaled_bl;
+		}
+		if (scaled_desc < max_desc) {
+			max_desc = scaled_desc;
+		}
+		if (scaled_lg > max_lg) {
+			max_lg = scaled_lg;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
 			curr_font = otFonts.otBold;
-			sf = bdMetrics.sf;
-			baseline = bdMetrics.baseline;
-			lg = bdMetrics.lg;
+			sf = bdSF;
 			ELOG("[FBInk] Unformatted text defaulting to bold font");
 		}
 	}
 	if (otFonts.otBoldItalic) {
-		bditMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otBoldItalic, (float)font_size_px);
-		stbtt_GetFontVMetrics(otFonts.otRegular, &bditMetrics.asc, &bditMetrics.desc, &bditMetrics.lg);
-		bditMetrics.baseline = (int)lroundf(bditMetrics.sf * bditMetrics.asc);
-		int height = (int)lroundf(bditMetrics.sf * (bditMetrics.asc - bditMetrics.desc + bditMetrics.lg));
-		if (height > max_font_height) {
-			max_font_height = height;
+		bditSF = stbtt_ScaleForPixelHeight(otFonts.otBoldItalic, (float)font_size_px);
+		stbtt_GetFontVMetrics(otFonts.otBoldItalic, &asc, &desc, &lg);
+		scaled_bl = (int)(ceilf(bditSF * asc));
+		scaled_desc = (int)(ceilf(bditSF * desc));
+		scaled_lg = (int)(ceilf(bditSF * lg));
+		if (scaled_bl > max_baseline) {
+			max_baseline = scaled_bl;
+		}
+		if (scaled_desc < max_desc) {
+			max_desc = scaled_desc;
+		}
+		if (scaled_lg > max_lg) {
+			max_lg = scaled_lg;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
 			curr_font = otFonts.otBoldItalic;
-			sf = bditMetrics.sf;
-			baseline = bditMetrics.baseline;
-			lg = bditMetrics.lg;
-			ELOG("[FBInk] Unformatted text defaulting to bold italic font");
+			sf = bditSF;
+			ELOG("[FBInk] Unformatted text defaulting to bold font");
 		}
 	}
 	// If no font was loaded, exit early. We checked earlier, but just in case...
@@ -2950,9 +2965,11 @@ int
 		rv = ERRCODE(ENOENT);
 		goto cleanup;
 	}
-	// And if max_font_height was not changed from zero, this is also an unrecoverable error.
+	printf("Max BL: %d  Max Desc: %d  Max LG: %d\n", max_baseline, max_desc, max_lg);
+	max_row_height = max_baseline + abs(max_desc) + max_lg;
+	// And if max_row_height was not changed from zero, this is also an unrecoverable error.
 	// Also guards against a potential divide-by-zero in the following calculation
-	if (max_font_height <= 0) {
+	if (max_row_height <= 0) {
 		ELOG("[FBInk] Max line height not set");
 		rv = ERRCODE(EXIT_FAILURE);
 		goto cleanup;
@@ -2960,7 +2977,7 @@ int
 
 	// Calculate the maximum number of lines we may have to deal with
 	unsigned int print_height = area.br.y - area.tl.y;
-	unsigned int num_lines = print_height / max_font_height;
+	unsigned int num_lines = print_height / max_row_height;
 
 	// And allocate the memory for it...
 	lines = calloc(num_lines, sizeof(FBInkOTLine));
@@ -2999,6 +3016,7 @@ int
 	uint32_t c;
 	unsigned short max_lw = area.br.x - area.tl.x;
 	unsigned int line;
+	int max_line_height = max_row_height - max_lg;
 	// adv = advance: the horizontal distance along the baseline to the origin of
 	//                the next glyph
 	// lsb = left side bearing: The horizontal distance from the origin point to
@@ -3013,6 +3031,7 @@ int
 		lw = 0;
 		lines[line].startCharIndex = c_index;
 		lines[line].line_used = true;
+		lines[line].line_gap = max_lg;
 		while (c_index < chars_in_str) {
 			if (cfg->is_formatted) {
 				// Check if we need to skip formatting characters
@@ -3023,19 +3042,19 @@ int
 					switch (fmt_buff[c_index]) {
 					case CH_REGULAR:
 						curr_font = otFonts.otRegular;
-						sf = rgMetrics.sf;
+						sf = rgSF;
 						break;
 					case CH_ITALIC:
 						curr_font = otFonts.otItalic;
-						sf = itMetrics.sf;
+						sf = itSF;
 						break;
 					case CH_BOLD:
 						curr_font = otFonts.otBold;
-						sf = bditMetrics.sf;
+						sf = bdSF;
 						break;
 					case CH_BOLD_ITALIC:
 						curr_font = otFonts.otBoldItalic;
-						sf = bditMetrics.sf;
+						sf = bditSF;
 						break;
 					}
 				}
@@ -3059,19 +3078,25 @@ int
 			c = u8_nextchar(string, &c_index);
 			// Note, these metrics are unscaled, we need to use our previously
 			// obtained scale factor (sf) to get the metrics as pixels
-			stbtt_GetCodepointHMetrics(curr_font, (int)c, &adv, &lsb);
-
-			// If starting a line with a character that has a negative lsb
-			// eg 'j', move our start point a little.
-			if (curr_x == 0 && lsb < 0) {
-				curr_x += (int)roundf(sf * abs(lsb));
-			}
+			stbtt_GetCodepointHMetrics(curr_font, c, &adv, &lsb);
 			stbtt_GetCodepointBitmapBox(curr_font, c, sf, sf, &x0, &y0, &x1, &y1);
 			gw = x1 - x0;
 			// Ensure that curr_x never goes negative
 			cx = curr_x;
 			if (cx + x0 < 0) {
 				curr_x += abs(cx + x0);
+			}
+			// Handle the situation where the metrics may lie, and the glyph descends
+			// below what the metrics say.
+			if (max_baseline + y1 > max_line_height) {
+				int height_diff = (max_baseline + y1) - max_line_height;
+				printf("Height Diff: %d, available LG: %d\n", height_diff, lines[line].line_gap);
+				if (height_diff > lines[line].line_gap) {
+					lines[line].line_gap = 0;
+				} else {
+					lines[line].line_gap -= height_diff;
+				}
+				max_line_height = max_baseline + y1;
 			}
 			// stb_truetype does not appear to create a bounding box for space characters,
 			// so we need to handle this situation.
@@ -3140,7 +3165,7 @@ int
 	// Create a bitmap buffer to render a single line. We don't render the glyphs directly to the
 	// fb here, as we need to do some simple blending, and it makes it easier to calculate our
 	// centering if required.
-	line_buff = calloc(max_lw * font_size_px, sizeof(*line_buff));
+	line_buff = calloc(max_lw * max_line_height, sizeof(*line_buff));
 	// We also don't want to be creating a new buffer for every glyph
 	glyph_buff = calloc(font_size_px * font_size_px * 8, sizeof(*glyph_buff));
 	if (!line_buff || !glyph_buff) {
@@ -3157,9 +3182,15 @@ int
 	unsigned short start_x, start_y;
 	// stb_truetype renders glyphs with color inverted to what our blitting functions expect
     unsigned char invert = cfg->is_inverted ? 0x00 : 0xFF;
+	bool abort_line = false;
 	// Render!
 	for (line = 0; line < num_lines; line++) {
 		if (!lines[line].line_used) {
+			break;
+		}
+		// We have run out of (vertical) printable area, most likely due to incorrect font
+		// metrics in the font.
+		if (abort_line) {
 			break;
 		}
 		printf("Line # %d\n", line);
@@ -3174,32 +3205,24 @@ int
 					switch (fmt_buff[ci]) {
 					case CH_REGULAR:
 						curr_font = otFonts.otRegular;
-						sf = rgMetrics.sf;
-						lg = rgMetrics.lg;
-						baseline = rgMetrics.baseline;
+						sf = rgSF;
 						break;
 					case CH_ITALIC:
 						curr_font = otFonts.otItalic;
-						sf = itMetrics.sf;
-						lg = itMetrics.lg;
-						baseline = itMetrics.baseline;
+						sf = itSF;
 						break;
 					case CH_BOLD:
 						curr_font = otFonts.otBold;
-						sf = bditMetrics.sf;
-						lg = bditMetrics.lg;
-						baseline = bditMetrics.baseline;
+						sf = bdSF;
 						break;
 					case CH_BOLD_ITALIC:
 						curr_font = otFonts.otBoldItalic;
-						sf = bditMetrics.sf;
-						lg = bditMetrics.lg;
-						baseline = bditMetrics.baseline;
+						sf = bditSF;
 						break;
 					}
 				}
 			}
-			curr_point.y = ins_point.y = baseline;
+			curr_point.y = ins_point.y = max_baseline;
 			c = u8_nextchar(string, &ci);
 			stbtt_GetCodepointHMetrics(curr_font, c, &adv, &lsb);
 			stbtt_GetCodepointBitmapBox(curr_font, c, sf, sf, &x0, &y0, &x1, &y1);
@@ -3261,7 +3284,7 @@ int
 				tmp_c = u8_nextchar(string, &tmp_i);
 				curr_point.x += (unsigned short int) lroundf(sf * stbtt_GetCodepointKernAdvance(curr_font, c, tmp_c));
 			}
-			ins_point.y = baseline;
+			ins_point.y = max_baseline;
 		}
 		curr_point.x = 0;
 		// Right, we've rendered a line to a bitmap, time to display it.
@@ -3282,8 +3305,11 @@ int
 			paint_point.x = start_x;
 			paint_point.y++;
 		}
-		paint_point.y += (unsigned short int) lroundf(sf * lg);
+		paint_point.y += (unsigned short int)lines[line].line_gap;
 		paint_point.x = area.tl.x;
+		if (paint_point.y + max_line_height > area.br.y) {
+			abort_line = true;
+		}
 		// Woohoo, it's in our framebuffer! Let's refresh the screen.
 		struct mxcfb_rect region = { 0 };
 		region.left = start_x;
@@ -3296,7 +3322,7 @@ int
 		LOG("Printed Line!");
 		// And clear our line buffer for next use. The glyph buffer shouldn't
 		// need clearing, as stbtt_MakeCodepointBitmap() should overwrite it.
-		memset(line_buff, 0, (max_lw * font_size_px * sizeof(unsigned char)));
+		memset(line_buff, 0, (max_lw * max_line_height * sizeof(unsigned char)));
 	}
 
 	cleanup:

--- a/fbink.c
+++ b/fbink.c
@@ -3408,7 +3408,36 @@ int
 				paint_point.x = start_x;
 				paint_point.y++;
 			}
-		} 
+		} else if (is_bgless) {
+			for (int j = 0; j < font_size_px; j++) {
+				for (int k = 0; k < lw; k++) {
+					if (lnPtr[k] != bgcolor) {
+						color.r = color.b = color.g = lnPtr[k] ^ invert;
+						put_pixel(&paint_point, &color);
+					}
+					paint_point.x++;
+				}
+				lnPtr += max_lw;
+				paint_point.x = start_x;
+				paint_point.y++;
+			}
+		} else if (is_overlay) {
+			for (int j = 0; j < font_size_px; j++) {
+				for (int k = 0; k < lw; k++) {
+					if (lnPtr[k] != bgcolor) {
+						get_pixel(&paint_point, &color);
+						color.r ^= 0xFF;
+						color.b ^= 0xFF;
+						color.g ^= 0xFF;
+						put_pixel(&paint_point, &color);
+					}
+					paint_point.x++;
+				}
+				lnPtr += max_lw;
+				paint_point.x = start_x;
+				paint_point.y++;
+			}
+		}
 		paint_point.y += (unsigned short int)lines[line].line_gap;
 		paint_point.x = area.tl.x;
 		if (paint_point.y + max_line_height > area.br.y) {

--- a/fbink.c
+++ b/fbink.c
@@ -2685,11 +2685,15 @@ int
 	area.tl.y = (unsigned short)(cfg->margins.top / 100.0f * viewHeight);
 	area.br.x = (unsigned short)(viewWidth - (uint32_t)(cfg->margins.right / 100.0f * viewWidth));
 	area.br.y = (unsigned short)(viewHeight - (uint32_t)(cfg->margins.bottom / 100.0f * viewHeight));
-
+	// Set default font size if required
+	uint8_t size_pt = cfg->size_pt;
+	if (!size_pt) {
+		size_pt = 12;
+	}
 	// TODO: handle ppi properly
 	int ppi = 265;
 	// Given the ppi, convert point height to pixels. Note, 1pt is 1/72th of an inch
-	int font_size_px = (int)(ppi / 72.0f * cfg->size_pt);
+	int font_size_px = (int)(ppi / 72.0f * size_pt);
 	// Get the Scale Factor used for most of the stbtt functions
 	float sf = stbtt_ScaleForPixelHeight(&otFontInfo, (float)font_size_px);
 	// Get the max possible glyph height, and therefore calc the maximum number of lines

--- a/fbink.c
+++ b/fbink.c
@@ -2881,7 +2881,6 @@ int
 			paint_point.y++;
 		}
 		paint_point.y += (int)(sf * lg);
-#ifndef LINUX
 		// Woohoo, it's in our framebuffer! Let's refresh the screen.
 		struct mxcfb_rect region = { 0 };
 		region.left = start_x;
@@ -2889,7 +2888,6 @@ int
 		region.width = lw;
 		region.height = font_size_px;
 		refresh(fbfd, region, WAVEFORM_MODE_AUTO, false);
-#endif
 		LOG("Printed Line!");
 		// And clear our line buffer for next use. The glyph buffer shouldn't
 		// need clearing, as stbtt_MakeCodepointBitmap() should overwrite it.

--- a/fbink.c
+++ b/fbink.c
@@ -2956,7 +2956,7 @@ int
 		if (!curr_font) {
 			curr_font = otFonts.otBoldItalic;
 			sf = bditSF;
-			ELOG("[FBInk] Unformatted text defaulting to bold font");
+			ELOG("[FBInk] Unformatted text defaulting to bold italic font");
 		}
 	}
 	// If no font was loaded, exit early. We checked earlier, but just in case...
@@ -2976,8 +2976,9 @@ int
 	}
 
 	// Calculate the maximum number of lines we may have to deal with
-	unsigned int print_height = area.br.y - area.tl.y;
-	unsigned int num_lines = print_height / max_row_height;
+	unsigned int print_height, num_lines;
+	print_height = area.br.y - area.tl.y;
+	num_lines = print_height / max_row_height;
 
 	// And allocate the memory for it...
 	lines = calloc(num_lines, sizeof(FBInkOTLine));
@@ -3079,6 +3080,7 @@ int
 			// Note, these metrics are unscaled, we need to use our previously
 			// obtained scale factor (sf) to get the metrics as pixels
 			stbtt_GetCodepointHMetrics(curr_font, c, &adv, &lsb);
+			// But these are already scaled
 			stbtt_GetCodepointBitmapBox(curr_font, c, sf, sf, &x0, &y0, &x1, &y1);
 			gw = x1 - x0;
 			// Ensure that curr_x never goes negative
@@ -3105,7 +3107,7 @@ int
 			} else {
 				lw = curr_x + x0 + gw;
 			}
-			printf("Current Measured LW: %d  Line# %d\n", lw, line);
+			printf("Current Measured LW: %u  Line# %u\n", lw, line);
 			// Oops, we appear to have advanced too far :)
 			// Better backtrack to see if we can find a suitable break opportunity
 			//unsigned short ot_meas_padding = 3; // Just so we don't use a magic number
@@ -3156,9 +3158,9 @@ int
 			break;
 		}
 	}
-	ELOG("[FBInk] %d lines to be printed", line);
+	ELOG("[FBInk] %u lines to be printed", line);
 	if (!complete_str) {
-		ELOG("[FBInk] String too long. Truncated to %d characters", (c_index + 1));
+		ELOG("[FBInk] String too long. Truncated to %u characters", (c_index + 1));
 	}
 	// Hopefully, we have some lines to render!
 
@@ -3167,7 +3169,7 @@ int
 	// centering if required.
 	line_buff = calloc(max_lw * max_line_height, sizeof(*line_buff));
 	// We also don't want to be creating a new buffer for every glyph
-	glyph_buff = calloc(font_size_px * font_size_px * 8, sizeof(*glyph_buff));
+	glyph_buff = calloc(font_size_px * max_line_height * 8, sizeof(*glyph_buff));
 	if (!line_buff || !glyph_buff) {
 		ELOG("[FBInk] Line or glyph buffers could not be allocated");
 		rv = ERRCODE(EXIT_FAILURE);
@@ -3193,7 +3195,7 @@ int
 		if (abort_line) {
 			break;
 		}
-		printf("Line # %d\n", line);
+		printf("Line # %u\n", line);
 		lw = 0;
 		unsigned int ci;
 		for (ci = lines[line].startCharIndex; ci <= lines[line].endCharIndex;) {
@@ -3243,7 +3245,7 @@ int
 			} else {
 				lw = ins_point.x;
 			}
-			printf("Current Rendered LW: %u  Line# %d\n", lw, line);
+			printf("Current Rendered LW: %u  Line# %u\n", lw, line);
 			// Just in case our arithmetic was off by a pixel or two...
 			// Note that we are deliberately using a slightly shorter line
 			// width during the measurement phase, so this should not happen.

--- a/fbink.c
+++ b/fbink.c
@@ -2807,6 +2807,7 @@ int
 	int x0, y0, x1, y1, gw, gh, lw;
 	uint32_t tmp_c;
 	for (line = 0; lines[line].line_used; line++) {
+		printf("Line # %d\n", line);
 		lw = 0;
 		int ci;
 		for (ci = lines[line].startCharIndex; ci <= lines[line].endCharIndex;) {
@@ -2852,6 +2853,7 @@ int
 			ins_point.y = baseline;
 			printf("LW: %d\n", lw);
 		}
+		curr_point.x = 0;
 		// Right, we've rendered a line to a bitmap, time to display it.
 		if (cfg->is_centered) {
 			paint_point.x += (max_lw - lw) / 2;

--- a/fbink.c
+++ b/fbink.c
@@ -2806,6 +2806,8 @@ int
 	FBInkCoordinates paint_point = {area.tl.x, area.tl.y};
 	int x0, y0, x1, y1, gw, gh, lw;
 	uint32_t tmp_c;
+	unsigned char *lnPtr, *glPtr = NULL;
+	unsigned short start_x, start_y;
 	for (line = 0; lines[line].line_used; line++) {
 		printf("Line # %d\n", line);
 		lw = 0;
@@ -2823,6 +2825,10 @@ int
 			ins_point.x = curr_point.x + x0;
 			ins_point.y += y0;
 			lw = ins_point.x + gw;
+			// Just in case our arithmetic was off by a pixel or two...
+			if (lw > max_lw) {
+				gw -= lw - max_lw;
+			}
 			// Because the stbtt_MakeCodepointBitmap documentation is a bit vague on this
 			// point, the parameter 'out_stride' should be the width of the surface in our
 			// buffer. It's designed so that the glyph can be rendered directly to a screen buffer.
@@ -2831,8 +2837,8 @@ int
 			// dimensions of the glyph, so we set 'out_stride' to the glyph width.
 			stbtt_MakeCodepointBitmap(&otFontInfo, glyph_buff, gw, gh, gw, sf, sf, c);
 			// paint our glyph into the line buffer
-			unsigned char* lnPtr = line_buff + ins_point.x + (max_lw * ins_point.y);
-			unsigned char* glPtr = glyph_buff;
+			lnPtr = line_buff + ins_point.x + (max_lw * ins_point.y);
+			glPtr = glyph_buff;
 			for (int j = 0; j < gh; j++) {
 				for (int k = 0; k < gw; k++) {
 					// 0 value pixels are transparent
@@ -2859,9 +2865,9 @@ int
 			paint_point.x += (max_lw - lw) / 2;
 		}
 		FBInkColor color = { 0 };
-		unsigned short start_x = paint_point.x;
-		unsigned short start_y = paint_point.y;
-		unsigned char* lnPtr = line_buff;
+		start_x = paint_point.x;
+		start_y = paint_point.y;
+		lnPtr = line_buff;
 		for (int j = 0; j < font_size_px; j++) {
 			for (int k = 0; k < lw; k++) {
 				color.r = color.b = color.g = OT_INVERT_PIXEL(lnPtr[k]);

--- a/fbink.c
+++ b/fbink.c
@@ -3322,7 +3322,7 @@ int
 			// Ensure that our glyph size does not exceed the buffer size. Resize the buffer if it does
 			if (gw * gh > (int)glyph_buffer_dims) {
 				unsigned int new_buff_size = (unsigned int)gw * (unsigned int)gh * 2U * sizeof(unsigned char);
-				unsigned char tmp_g_buff = NULL;
+				unsigned char *tmp_g_buff = NULL;
 				tmp_g_buff = realloc(glyph_buff, new_buff_size);
 				if (!tmp_g_buff) {
 					ELOG("[FBInk] Failure resizing glyph buffer");

--- a/fbink.c
+++ b/fbink.c
@@ -2912,6 +2912,10 @@ int
 	// Note: we only care about the byte length here
 	size_t str_len_bytes = strlen(string);
 	brk_buff = calloc(str_len_bytes + 1, sizeof(char));
+	if (!brk_buff) {
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
 
 	init_linebreak();
 	set_linebreaks_utf8((utf8_t*)string, str_len_bytes + 1, "en", brk_buff);
@@ -2919,6 +2923,10 @@ int
 
 	// Parse our string for formatting, if requested
 	fmt_buff = calloc(str_len_bytes, sizeof(char));
+	if (!fmt_buff) {
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
 	if (cfg->is_formatted) {
 		parse_simple_md(string, str_len_bytes, fmt_buff);
 	}
@@ -3162,6 +3170,7 @@ int
 			paint_point.y++;
 		}
 		paint_point.y += (int)(sf * lg);
+		paint_point.x = area.tl.x;
 		// Woohoo, it's in our framebuffer! Let's refresh the screen.
 		struct mxcfb_rect region = { 0 };
 		region.left = start_x;

--- a/fbink.c
+++ b/fbink.c
@@ -2715,7 +2715,7 @@ int
 void 
 	parse_simple_md(char* string, int size, unsigned char* result)
 {
-	int ci;
+	int ci = 0;
 	bool is_italic = false;
 	bool is_bold = false;
 	while (ci < size) {

--- a/fbink.c
+++ b/fbink.c
@@ -3305,6 +3305,7 @@ int
 					ERRCODE(EXIT_FAILURE);
 					goto cleanup;
 				}
+				glyph_buffer_dims = new_buff_size;
 			}
 			// Make sure we don't have an underflow/wrap around
 			cx = (int)curr_point.x;

--- a/fbink.c
+++ b/fbink.c
@@ -2867,7 +2867,7 @@ int
 		int lg;
 		int baseline;
 	};
-	int max_height = 0;
+	int max_font_height = 0;
 	// Calculate some metrics for every font we have loaded.
 	// Please forgive the repetition here.
 
@@ -2880,9 +2880,9 @@ int
 		rgMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otRegular, (float)font_size_px);
 		stbtt_GetFontVMetrics(otFonts.otRegular, &rgMetrics.asc, &rgMetrics.desc, &rgMetrics.lg);
 		rgMetrics.baseline = (int)roundf(rgMetrics.sf * rgMetrics.asc);
-		int height = (int)roundf(rgMetrics.sf * (rgMetrics.asc - rgMetrics.desc));
-		if (height > max_height) {
-			max_height = height;
+		int height = (int)roundf(rgMetrics.sf * (rgMetrics.asc - rgMetrics.desc + rgMetrics.lg));
+		if (height > max_font_height) {
+			max_font_height = height;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
@@ -2897,9 +2897,9 @@ int
 		itMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otItalic, (float)font_size_px);
 		stbtt_GetFontVMetrics(otFonts.otRegular, &itMetrics.asc, &itMetrics.desc, &itMetrics.lg);
 		itMetrics.baseline = (int)roundf(itMetrics.sf * itMetrics.asc);
-		int height = (int)roundf(itMetrics.sf * (itMetrics.asc - itMetrics.desc));
-		if (height > max_height) {
-			max_height = height;
+		int height = (int)roundf(itMetrics.sf * (itMetrics.asc - itMetrics.desc + itMetrics.lg));
+		if (height > max_font_height) {
+			max_font_height = height;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
@@ -2914,9 +2914,9 @@ int
 		bdMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otBold, (float)font_size_px);
 		stbtt_GetFontVMetrics(otFonts.otRegular, &bdMetrics.asc, &bdMetrics.desc, &bdMetrics.lg);
 		bdMetrics.baseline = (int)roundf(bdMetrics.sf * bdMetrics.asc);
-		int height = (int)roundf(bdMetrics.sf * (bdMetrics.asc - bdMetrics.desc));
-		if (height > max_height) {
-			max_height = height;
+		int height = (int)roundf(bdMetrics.sf * (bdMetrics.asc - bdMetrics.desc + bdMetrics.lg));
+		if (height > max_font_height) {
+			max_font_height = height;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
@@ -2931,9 +2931,9 @@ int
 		bditMetrics.sf = stbtt_ScaleForPixelHeight(otFonts.otBoldItalic, (float)font_size_px);
 		stbtt_GetFontVMetrics(otFonts.otRegular, &bditMetrics.asc, &bditMetrics.desc, &bditMetrics.lg);
 		bditMetrics.baseline = (int)roundf(bditMetrics.sf * bditMetrics.asc);
-		int height = (int)roundf(bditMetrics.sf * (bditMetrics.asc - bditMetrics.desc));
-		if (height > max_height) {
-			max_height = height;
+		int height = (int)roundf(bditMetrics.sf * (bditMetrics.asc - bditMetrics.desc + bditMetrics.lg));
+		if (height > max_font_height) {
+			max_font_height = height;
 		}
 		// Set default font, for when markdown parsing is disabled
 		if (!curr_font) {
@@ -2950,16 +2950,17 @@ int
 		rv = ERRCODE(ENOENT);
 		goto cleanup;
 	}
-	// And if max_height was not changed from zero, this is also an unrecoverable error.
+	// And if max_font_height was not changed from zero, this is also an unrecoverable error.
 	// Also guards against a potential divide-by-zero in the following calculation
-	if (max_height <= 0) {
+	if (max_font_height <= 0) {
 		ELOG("[FBInk] Max line height not set");
 		rv = ERRCODE(EXIT_FAILURE);
 		goto cleanup;
 	}
 
 	// Calculate the maximum number of lines we may have to deal with
-	unsigned int num_lines = (unsigned int)(viewHeight / (uint32_t)max_height);
+	unsigned int print_height = area.br.y - area.tl.y;
+	unsigned int num_lines = print_height / max_font_height;
 	
 	// And allocate the memory for it...
 	lines = calloc(num_lines, sizeof(FBInkOTLine));

--- a/fbink.c
+++ b/fbink.c
@@ -2821,6 +2821,8 @@ int
 	uint32_t tmp_c;
 	unsigned char *lnPtr, *glPtr = NULL;
 	unsigned short start_x, start_y;
+	// stb_truetype renders glyphs with color inverted to what our blitting functions expect
+	unsigned char invert = 0xff;
 	// Render!
 	for (line = 0; lines[line].line_used; line++) {
 		printf("Line # %d\n", line);
@@ -2884,7 +2886,7 @@ int
 		lnPtr = line_buff;
 		for (int j = 0; j < font_size_px; j++) {
 			for (int k = 0; k < lw; k++) {
-				color.r = color.b = color.g = OT_INVERT_PIXEL(lnPtr[k]);
+				color.r = color.b = color.g = lnPtr[k] ^ invert;
 				put_pixel(&paint_point, &color);
 				paint_point.x++;
 			}

--- a/fbink.c
+++ b/fbink.c
@@ -2750,9 +2750,9 @@ int
 				curr_x += (int)roundf(sf * abs(lsb));
 			}
 			int x0, x1;
-			stbtt_GetCodepointBox(&otFontInfo, c, &x0, 0, &x1, 0);
-			int gw_from_origin = (int)roundf(sf * (x1 - x0)) - (int)roundf(sf * lsb);
-			printf("GW: %d\n", ((int)roundf(sf * (x1 - x0))));
+			stbtt_GetCodepointBitmapBox(&otFontInfo, c, sf, sf, &x0, 0, &x1, 0);
+			int gw_from_origin = x1;
+			printf("GW: %d\n", (x1 - x0));
 			printf("Calced LW: %d\n", (curr_x + gw_from_origin));
 			// Oops, we appear to have advanced too far :)
 			// Better backtrack to see if we can find a suitable break opportunity

--- a/fbink.c
+++ b/fbink.c
@@ -3048,7 +3048,7 @@ int
 				// u8_nextchar() 'consumes' a character.
 				u8_dec(string, &c_index);
 				lines[line].endCharIndex = c_index;
-				for (c_index; c_index > lines[line].startCharIndex; u8_dec(string, &c_index)) {
+				for (; c_index > lines[line].startCharIndex; u8_dec(string, &c_index)) {
 					if (brk_buff[c_index] == LINEBREAK_ALLOWBREAK) {
 						lines[line].endCharIndex = c_index;
 						break;
@@ -3079,9 +3079,9 @@ int
 	// Create a bitmap buffer to render a single line. We don't render the glyphs directly to the
 	// fb here, as we need to do some simple blending, and it makes it easier to calculate our
 	// centering if required.
-	line_buff = calloc(max_lw * font_size_px, sizeof(char));
+	line_buff = calloc(max_lw * font_size_px, sizeof(unsigned char));
 	// We also don't want to be creating a new buffer for every glyph
-	glyph_buff = calloc(font_size_px * font_size_px * 2, sizeof(char));
+	glyph_buff = calloc(font_size_px * font_size_px * 2, sizeof(unsigned char));
 	if (!line_buff || !glyph_buff) {
 		goto cleanup;
 	}

--- a/fbink.c
+++ b/fbink.c
@@ -2901,6 +2901,8 @@ int
 		region.top = start_y;
 		region.width = lw;
 		region.height = font_size_px;
+		// Rotate our eink refresh region before refreshing
+		(*fxpRotateRegion)(&region);
 		refresh(fbfd, region, WAVEFORM_MODE_AUTO, false);
 		LOG("Printed Line!");
 		// And clear our line buffer for next use. The glyph buffer shouldn't

--- a/fbink.c
+++ b/fbink.c
@@ -2819,10 +2819,16 @@ int
 			gw = x1 - x0;
 			printf("BMGW: %d\n", gw);
 			gh = y1 - y0;
-			ins_point.x = curr_point.x + (int)roundf(lsb * sf);
+			ins_point.x = curr_point.x + x0;
 			ins_point.y += y0;
 			lw = ins_point.x + gw;
-			stbtt_MakeCodepointBitmap(&otFontInfo, glyph_buff, gw, gh, 0, sf, sf, c);
+			// Because the stbtt_MakeCodepointBitmap documentation is a bit vague on this
+			// point, the parameter 'out_stride' should be the width of the surface in our
+			// buffer. It's designed so that the glyph can be rendered directly to a screen buffer.
+			// For example, if we were rendering directly to a screen of 1080 x 1440m out_stride
+			// should be set to 1080. In this case however, we want to render to a 'box' of the
+			// dimensions of the glyph, so we set 'out_stride' to the glyph width.
+			stbtt_MakeCodepointBitmap(&otFontInfo, glyph_buff, gw, gh, gw, sf, sf, c);
 			// paint our glyph into the line buffer
 			unsigned char* lnPtr = line_buff + ins_point.x + (max_lw * ins_point.y);
 			unsigned char* glPtr = glyph_buff;

--- a/fbink.h
+++ b/fbink.h
@@ -198,6 +198,7 @@ typedef struct {
 	} margins;
 	bool is_centered;         // Horizontal text centering
 	bool is_formatted;		  // Is string "formatted"? Bold/Italic support only, markdown like syntax
+    bool is_inverted;
 } FBInkOTConfig;
 
 // NOTE: Unless otherwise specified,
@@ -271,7 +272,7 @@ FBINK_API int fbink_printf(int fbfd, const FBInkConfig* fbink_config, const char
     __attribute__((format(printf, 3, 4)));
 
 // Print a string using an OpenType font. Note the caller MUST init with fbink_init_ot() FIRST.
-// This function uses margins (as whole number percentages) instead of rows/columns for 
+// This function uses margins (as whole number percentages) instead of rows/columns for
 // positioning and setting the printable area.
 // Returns -(ERANGE) if the provided margins are out of range, or sum to < 100%
 // Returns -(ENOSYS) if compiled with MINIMAL

--- a/fbink.h
+++ b/fbink.h
@@ -260,6 +260,7 @@ FBINK_API int fbink_printf(int fbfd, const FBInkConfig* fbink_config, const char
 // positioning and setting the printable area.
 // Returns -(ERANGE) if the provided margins are out of range, or sum to < 100%
 // Returns -(ENOSYS) if compiled with MINIMAL
+// Returns -(ENODAT) if fbink_init_ot() hasn't yet been called.
 // fbfd:		open file descriptor to the framebuffer character device,
 //				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call
 // string:		UTF-8 encoded string to print

--- a/fbink.h
+++ b/fbink.h
@@ -191,14 +191,13 @@ typedef struct
 typedef struct {
 	uint8_t size_pt;          // Size of text in points. If not set (0), defaults to 12pt
 	struct {
-		unsigned char top;    // Top margin as percentage. Max 90%
-		unsigned char bottom; // Bottom margin as percentage. Max 90%
-		unsigned char left;   // Left margin as percentage. Max 90%
-		unsigned char right;  // Right margin as percentage. Max 90%
+		unsigned short top;    // Top margin in pixels
+		unsigned short bottom; // Bottom margin in pixels
+		unsigned short left;   // Left margin in pixels
+		unsigned short right;  // Right margin in pixels
 	} margins;
 	bool is_centered;         // Horizontal text centering
 	bool is_formatted;		  // Is string "formatted"? Bold/Italic support only, markdown like syntax
-    bool is_inverted;
 } FBInkOTConfig;
 
 // NOTE: Unless otherwise specified,
@@ -274,7 +273,10 @@ FBINK_API int fbink_printf(int fbfd, const FBInkConfig* fbink_config, const char
 // Print a string using an OpenType font. Note the caller MUST init with fbink_init_ot() FIRST.
 // This function uses margins (as whole number percentages) instead of rows/columns for
 // positioning and setting the printable area.
-// Returns -(ERANGE) if the provided margins are out of range, or sum to < 100%
+// Returns new top margin for use in subsequent calls, if the return value is positive.
+// 		A zero return value indicates there is no room left to print another row of text at the current
+// 		margins or font size.
+// Returns -(ERANGE) if the provided margins are out of range, or sum to < view height or width
 // Returns -(ENOSYS) if compiled with MINIMAL
 // Returns -(ENODAT) if fbink_init_ot() hasn't yet been called.
 // fbfd:		open file descriptor to the framebuffer character device,

--- a/fbink.h
+++ b/fbink.h
@@ -180,6 +180,17 @@ typedef struct
 	uint8_t   valign;    // Vertical alignment of images (NONE/TOP, CENTER, EDGE/BOTTOM; c.f., ALIGN_INDEX_T enum)
 } FBInkConfig;
 
+typedef struct {
+	uint8_t size_pt;
+	struct {
+		unsigned char top;
+		unsigned char bottom;
+		unsigned char left;
+		unsigned char right;
+	} margins;
+	bool is_centered;
+} FBInkOTConfig;
+
 // NOTE: Unless otherwise specified,
 //       stuff returns a negative value (usually -(EXIT_FAILURE)) on failure & EXIT_SUCCESS otherwise ;).
 
@@ -214,6 +225,7 @@ FBINK_API int fbink_close(int fbfd);
 //       c.f., KFMon's handling of this via fbink_is_fb_quirky() to detect the initial 16bpp -> 32bpp switch.
 FBINK_API int fbink_init(int fbfd, const FBInkConfig* fbink_config);
 
+FBINK_API int fbink_init_ot(const unsigned char* font_data);
 // Dump a few of our internal state variables to stdout, in a format easily consumable by a shell (i.e., eval)
 FBINK_API void fbink_state_dump(const FBInkConfig* fbink_config);
 
@@ -239,6 +251,7 @@ FBINK_API int fbink_print(int fbfd, const char* string, const FBInkConfig* fbink
 FBINK_API int fbink_printf(int fbfd, const FBInkConfig* fbink_config, const char* fmt, ...)
     __attribute__((format(printf, 3, 4)));
 
+FBINK_API int fbink_print_ot(int fbfd, char* string, FBInkOTConfig* cfg);
 // A simple wrapper around the internal screen refresh handling, without requiring you to include einkfb/mxcfb headers
 // fbfd:		open file descriptor to the framebuffer character device,
 //				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call

--- a/fbink.h
+++ b/fbink.h
@@ -281,7 +281,10 @@ FBINK_API int fbink_printf(int fbfd, const FBInkConfig* fbink_config, const char
 //				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call
 // string:		UTF-8 encoded string to print
 // cfg:			Pointer to a FBInkOTConfig struct.
-FBINK_API int fbink_print_ot(int fbfd, char* string, FBInkOTConfig* cfg);
+// fbCfg:		Optional pointer to a FBInkConfig struct. If set, the options
+//				is_inverted, is_overlay, is_fgless, is_bgless, fg_color, bg_color, valign, halign
+//              will be honored.
+FBINK_API int fbink_print_ot(int fbfd, char* string, FBInkOTConfig* cfg, FBInkConfig* fbCfg);
 
 // A simple wrapper around the internal screen refresh handling, without requiring you to include einkfb/mxcfb headers
 // fbfd:		open file descriptor to the framebuffer character device,

--- a/fbink.h
+++ b/fbink.h
@@ -77,6 +77,14 @@ typedef enum
 	SCIENTIFICAI       // scientifica (italic)
 } FONT_INDEX_T;
 
+typedef enum
+{
+	FNT_REGULAR = 0U,
+	FNT_ITALIC,
+	FNT_BOLD,
+	FNT_BOLD_ITALIC
+} FONT_VARIANT_T;
+
 // List of available halign/valign values
 typedef enum
 {
@@ -225,10 +233,16 @@ FBINK_API int fbink_close(int fbfd);
 //       c.f., KFMon's handling of this via fbink_is_fb_quirky() to detect the initial 16bpp -> 32bpp switch.
 FBINK_API int fbink_init(int fbfd, const FBInkConfig* fbink_config);
 
-// If using OpenType fonts, this initialises a font for use by FBInk.
-// The caller should load the font data into a buffer and pass that data in.
-// NOTE: The caller MUST NOT free this font_data untill you are done printing. 
-FBINK_API int fbink_init_ot(const unsigned char* font_data);
+// Add an OpenType font to FBInk. Note that at least one font must be added in order to use fbink_print_ot()
+// Returns -(EXIT_FAILURE) on failure, or EXIT_SUCCESS otherwise
+// fp:      The font file path. This should be a valid *.otf or *.ttf font
+// variant: What variant of font this is (FNT_REGULAR, FNT_ITALIC, FNT_BOLD, FNT_BOLD_ITALIC)
+// NOTE:    You MUST free the fonts loaded when you are fone by calling fbink_free_ot_fonts()
+// NOTE:    You may replace a font without first calling free
+FBINK_API int fbink_add_ot_font(const char* fp, FONT_VARIANT_T variant);
+
+// Free all loaded OpenType fonts. You MUST call this when you have finished all OT printing.
+FBINK_API int fbink_free_ot_fonts(void);
 
 // Dump a few of our internal state variables to stdout, in a format easily consumable by a shell (i.e., eval)
 FBINK_API void fbink_state_dump(const FBInkConfig* fbink_config);

--- a/fbink.h
+++ b/fbink.h
@@ -197,6 +197,7 @@ typedef struct {
 		unsigned char right;  // Right margin as percentage. Max 90%
 	} margins;
 	bool is_centered;         // Horizontal text centering
+	bool is_formatted;		  // Is string "formatted"? Bold/Italic support only, markdown like syntax
 } FBInkOTConfig;
 
 // NOTE: Unless otherwise specified,

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -694,11 +694,16 @@ int
 			FBInkOTConfig cfg = { 0 };
 			cfg.is_formatted = true;
 			cfg.margins.top = 5;
-			cfg.size_pt = 36;
-			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Regular.ttf", FNT_REGULAR);
-			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Italic.ttf", FNT_ITALIC);
-			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Bold.ttf", FNT_BOLD);
-			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-BoldItalic.ttf", FNT_BOLD_ITALIC);
+			cfg.size_pt = 18; 
+			// fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Regular.ttf", FNT_REGULAR);
+			// fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Italic.ttf", FNT_ITALIC);
+			// fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Bold.ttf", FNT_BOLD);
+			// fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-BoldItalic.ttf", FNT_BOLD_ITALIC);
+
+			fbink_add_ot_font("/mnt/onboard/fonts/Alegreya-Regular.ttf", FNT_REGULAR);
+			fbink_add_ot_font("/mnt/onboard/fonts/Alegreya-Italic.ttf", FNT_ITALIC);
+			fbink_add_ot_font("/mnt/onboard/fonts/Alegreya-Bold.ttf", FNT_BOLD);
+			fbink_add_ot_font("/mnt/onboard/fonts/Alegreya-BoldItalic.ttf", FNT_BOLD_ITALIC);
 			fbink_print_ot(fbfd, string, &cfg);
 			fbink_free_ot_fonts();
         	/*

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -690,11 +690,23 @@ int
 				    fbink_config.fontname,
 				    fbink_config.fontmult);
 			}
+			// TTF!
+			FBInkOTConfig cfg = { 0 };
+			cfg.is_formatted = true;
+			cfg.margins.top = 5;
+			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Regular.ttf", FNT_REGULAR);
+			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Italic.ttf", FNT_ITALIC);
+			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Bold.ttf", FNT_BOLD);
+			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-BoldItalic.ttf", FNT_BOLD_ITALIC);
+			fbink_print_ot(fbfd, string, &cfg);
+			fbink_free_ot_fonts();
+        	/*
 			if ((linecount = fbink_print(fbfd, string, &fbink_config)) < 0) {
 				fprintf(stderr, "Failed to print that string!\n");
 				rv = ERRCODE(EXIT_FAILURE);
 				goto cleanup;
 			}
+       		*/
 			// NOTE: Don't clobber previous entries if multiple strings were passed...
 			//       We make sure to trust print's return value,
 			//       because it knows how much space it already took up ;).

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -694,6 +694,7 @@ int
 			FBInkOTConfig cfg = { 0 };
 			cfg.is_formatted = true;
 			cfg.margins.top = 5;
+			cfg.size_pt = 36;
 			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Regular.ttf", FNT_REGULAR);
 			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Italic.ttf", FNT_ITALIC);
 			fbink_add_ot_font("/mnt/onboard/fonts/Bookerly-Bold.ttf", FNT_BOLD);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -263,6 +263,7 @@ const uint32_t* (*fxpFont32xGetBitmap)(uint32_t) = NULL;
 FBInkDeviceQuirks deviceQuirks = { 0 };
 
 // Information about the currently loaded OpenType font
+bool otInit = false;
 stbtt_fontinfo otFontInfo = { 0 };
 
 #ifndef FBINK_FOR_KINDLE

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -126,9 +126,6 @@
 #	include "fbink_misc_fonts.h"
 #endif
 
-// We need a definition from stb_truetype.h
-#include "stb/stb_truetype.h"
-
 // NOTE: CLOEXEC shenanigans...
 //       Story time: it was introduced (for open) in Linux 2.6.23. Kindle FW 2.x runs something older,
 //       and I can't be arsed to check if they backported it in there or not.
@@ -260,7 +257,7 @@ FBInkDeviceQuirks deviceQuirks = { 0 };
 
 // Information about the currently loaded OpenType font
 bool otInit = false;
-stbtt_fontinfo otFontInfo = { 0 };
+FBInkOTFonts otFonts = { NULL, NULL, NULL, NULL };
 
 #ifndef FBINK_FOR_KINDLE
 static void rotate_coordinates_pickel(FBInkCoordinates*);
@@ -339,6 +336,10 @@ static unsigned char* img_load_from_file(const char*, int*, int*, int*, int);
 static unsigned char* img_convert_px_format(unsigned char*, int, int, int, int);
 static int
     draw_image(int, unsigned char*, const int, const int, const int, const int, short int, short int, const FBInkConfig*);
+#endif
+
+#ifdef FBINK_WITH_OPENTYPE
+static void* free_ot_font(stbtt_fontinfo* font_info);
 #endif
 
 // For identify_device, which we need outside of fbink_device_id.c ;)

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -347,6 +347,7 @@ static int
 
 #ifdef FBINK_WITH_OPENTYPE
 static void* free_ot_font(stbtt_fontinfo* font_info);
+static void parse_simple_md(char* string, int size, unsigned char* result);
 #endif
 
 // For identify_device, which we need outside of fbink_device_id.c ;)

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -126,6 +126,9 @@
 #	include "fbink_misc_fonts.h"
 #endif
 
+// We need a definition from stb_truetype.h
+#include "stb/stb_truetype.h"
+
 // NOTE: CLOEXEC shenanigans...
 //       Story time: it was introduced (for open) in Linux 2.6.23. Kindle FW 2.x runs something older,
 //       and I can't be arsed to check if they backported it in there or not.
@@ -201,6 +204,10 @@
 // We want to return negative values on failure, always
 #define ERRCODE(e) (-(e))
 
+// stb_truetype bitmaps are 8bpp, with 0 being transparent and
+// 255 fully opaque
+#define OT_INVERT_PIXEL(x) (255 - (x))
+
 // eInk color map
 // c.f., linux/drivers/video/mxc/cmap_lab126.h
 // NOTE: Legacy devices have an inverted color map, which we handle internally!
@@ -254,6 +261,9 @@ const uint32_t* (*fxpFont32xGetBitmap)(uint32_t) = NULL;
 
 // Where we track device/screen-specific quirks
 FBInkDeviceQuirks deviceQuirks = { 0 };
+
+// Information about the currently loaded OpenType font
+stbtt_fontinfo otFontInfo = { 0 };
 
 #ifndef FBINK_FOR_KINDLE
 static void rotate_coordinates_pickel(FBInkCoordinates*);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -36,6 +36,9 @@
 #	ifndef FBINK_WITH_IMAGE
 #		define FBINK_WITH_IMAGE
 #	endif
+#   ifndef FBINK_WITH_OPENTYPE
+#       define FBINK_WITH_OPENTYPE
+#   endif
 // Connect button scanning is Kobo specific
 #	ifndef FBINK_FOR_KINDLE
 #		ifndef FBINK_FOR_CERVANTES

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -204,10 +204,6 @@
 // We want to return negative values on failure, always
 #define ERRCODE(e) (-(e))
 
-// stb_truetype bitmaps are 8bpp, with 0 being transparent and
-// 255 fully opaque
-#define OT_INVERT_PIXEL(x) (255 - (x))
-
 // eInk color map
 // c.f., linux/drivers/video/mxc/cmap_lab126.h
 // NOTE: Legacy devices have an inverted color map, which we handle internally!

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -258,6 +258,13 @@ FBInkDeviceQuirks deviceQuirks = { 0 };
 // Information about the currently loaded OpenType font
 bool otInit = false;
 FBInkOTFonts otFonts = { NULL, NULL, NULL, NULL };
+typedef enum {
+	CH_IGNORE = 0U,
+	CH_REGULAR,
+	CH_ITALIC,
+	CH_BOLD,
+	CH_BOLD_ITALIC
+} CHARACTER_FONT;
 
 #ifndef FBINK_FOR_KINDLE
 static void rotate_coordinates_pickel(FBInkCoordinates*);

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "stb/stb_truetype.h"
 
 // List of flags for device or screen-specific quirks...
 typedef struct
@@ -136,4 +137,11 @@ typedef struct FBInkOTLine {
 	bool line_used;
 	int line_gap;
 } FBInkOTLine;
+
+typedef struct FBInkOTFonts {
+	stbtt_fontinfo* otRegular;
+	stbtt_fontinfo* otItalic;
+	stbtt_fontinfo* otBold;
+	stbtt_fontinfo* otBoldItalic;
+} FBInkOTFonts;
 #endif

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -128,4 +128,12 @@ typedef union
 	} color;
 } FBInkPixelBGR;
 
+// Stores the information necessary to render a line of text
+// using OpenType/TrueType fonts
+typedef struct FBInkOTLine {
+	unsigned int startCharIndex;
+	unsigned int endCharIndex;
+	bool line_used;
+	int line_gap;
+} FBInkOTLine;
 #endif

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -23,6 +23,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+// NOTE: We need to import stbtt early because we depend on stbtt_fontinfo here
+//       We'll want it as static/private, so do that here, because we're importing it earlier than fbink.c
+#define STBTT_STATIC
 #include "stb/stb_truetype.h"
 
 // List of flags for device or screen-specific quirks...

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -138,7 +138,6 @@ typedef struct FBInkOTLine {
 	unsigned int startCharIndex;
 	unsigned int endCharIndex;
 	bool line_used;
-	int line_gap;
 } FBInkOTLine;
 
 typedef struct FBInkOTFonts {

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -138,6 +138,7 @@ typedef struct FBInkOTLine {
 	unsigned int startCharIndex;
 	unsigned int endCharIndex;
 	bool line_used;
+	int line_gap;
 } FBInkOTLine;
 
 typedef struct FBInkOTFonts {


### PR DESCRIPTION
Hi NiLuJe

I decided to see if I could figure out this whole OpenType/TrueType thing...

I'm opening this pull request relatively early, so I hopefully don't go too far down the wrong track if I've done stuff you don't agree with and/or want changed. Consider this Not Done Yet.

With that out the way, here's what's working:
* Printing strings to screen in arbitrary font sizes (I'm using points)
* Line breaking using the libunibreaks library, which implements the Unicode UAX 14 algorithm. Linebreaking honors hard line breaks (line feeds etc).
* Users can specify arbitrary margins to set the maximum printable area. Currently using percentages, although I'm mulling the idea of moving to pixels directly.
* ~~Centered text~~ Oops, this seems a bit broken if I have linebreaks in there.

What's not implemented:
* Overlays, foreground/background colors
* Vertical centering
* Probably others.

I've done away with the rows/columns concept, as it doesn't make much sense when using proportional fonts. I've also currently created a new struct for the OT settings. We may wish to integrate these to the main FBInkConfig struct.

Nothing has been optimized yet. We may want to look at caching glyph bitmaps for example (although, that will increase memory usage).

I also haven't handled any rotation shenanigans, I'm not sure if what I've done requires this.

I look forward to getting your feedback on this. No rush though, you are allowed to sleep!

(Also, if I may make an observation on the current printing code? The rows/columns concept seems to be more trouble than its worth IMHO)