### PR TITLE
Allow larger font sizes, and fix UTF-8 iteration for OT support

### DIFF
--- a/fbink.c
+++ b/fbink.c
@@ -2872,9 +2872,9 @@ int
 	area.br.x = (unsigned short int) (viewWidth - cfg->margins.right);
 	area.br.y = (unsigned short int) (viewHeight - cfg->margins.bottom);
 	// Set default font size if required
-	uint8_t size_pt = cfg->size_pt;
+	unsigned short int size_pt = cfg->size_pt;
 	if (!size_pt) {
-		size_pt = 12;
+		size_pt = 12U;
 	}
 	// We should have a fairly accurate idea of what the screen DPI is...
 	unsigned short int ppi = deviceQuirks.screenDPI;

--- a/fbink.c
+++ b/fbink.c
@@ -3040,7 +3040,6 @@ int
 	// Lets find our lines! Nothing fancy, just a simple first fit algorithm, but we do
 	// our best not to break inside a word.
 
-	unsigned int       chars_in_str = u8_strlen(string);
 	unsigned int       c_index      = 0;
 	unsigned int       tmp_c_index  = c_index;
 	uint32_t           c;
@@ -3061,7 +3060,7 @@ int
 		lines[line].startCharIndex = c_index;
 		lines[line].line_gap       = max_lg;
 		lines[line].line_used      = true;
-		while (c_index < chars_in_str) {
+		while (c_index < str_len_bytes) {
 			if (cfg->is_formatted) {
 				// Check if we need to skip formatting characters
 				if (fmt_buff[c_index] == CH_IGNORE) {
@@ -3184,7 +3183,7 @@ int
 			}
 		}
 		// We've run out of string! This is our last line.
-		if (c_index >= chars_in_str) {
+		if (c_index >= str_len_bytes) {
 			u8_dec(string, &c_index);
 			lines[line].endCharIndex = c_index;
 			complete_str             = true;

--- a/fbink.h
+++ b/fbink.h
@@ -199,9 +199,9 @@ typedef struct
 		unsigned short int left;      // Left margin in pixels
 		unsigned short int right;     // Right margin in pixels
 	} margins;
-	uint8_t size_pt;         // Size of text in points. If not set (0), defaults to 12pt
-	bool    is_centered;     // Horizontal centering
-	bool    is_formatted;    // Is string "formatted"? Bold/Italic support only, markdown like syntax
+	unsigned short int size_pt;  // Size of text in points. If not set (0), defaults to 12pt
+	bool    is_centered;         // Horizontal centering
+	bool    is_formatted;        // Is string "formatted"? Bold/Italic support only, markdown like syntax
 } FBInkOTConfig;
 
 // NOTE: Unless otherwise specified,

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -695,7 +695,8 @@ int
 							bdit_ot_file = strdup(value);
 							break;
 						case SIZE_OPT:
-							ot_config.size_pt = (uint8_t) strtoul(value, NULL, 10);
+							ot_config.size_pt = 
+								(unsigned short int) strtoul(value, NULL, 10);
 							break;
 						case TM_OPT:
 							ot_config.margins.top =
@@ -831,7 +832,7 @@ int
 			if (is_truetype) {
 				if (!fbink_config.is_quiet) {
 					printf(
-					    "Printing string '%s' @ %hhupt, honoring the following margins { top: %hupx, bottom: %hupx, left: %hupx, right: %hupx } (formatted: %s, overlay: %s, backgroundless: %s, foregroundless: %s, inverted: %s, flashing: %s, centered: %s, halign: %hhu, halfway: %s, valign: %hhu, clear screen: %s)\n",
+					    "Printing string '%s' @ %hupt, honoring the following margins { top: %hupx, bottom: %hupx, left: %hupx, right: %hupx } (formatted: %s, overlay: %s, backgroundless: %s, foregroundless: %s, inverted: %s, flashing: %s, centered: %s, halign: %hhu, halfway: %s, valign: %hhu, clear screen: %s)\n",
 					    string,
 					    ot_config.size_pt,
 					    ot_config.margins.top,


### PR DESCRIPTION
Fixes the issues found [here](https://www.mobileread.com/forums/showpost.php?p=3768773&postcount=45).

I must have been having a brain fade when I implemented the string iteration loop. Hopefully this PR solves that. My test version seems to have worked, as seen [here](https://www.mobileread.com/forums/showpost.php?p=3768849&postcount=56)