### PR TITLE
Printf functionality for OT/TT users

### DIFF
--- a/fbink.c
+++ b/fbink.c
@@ -2811,6 +2811,70 @@ static void
 }
 #endif    // FBINK_WITH_OPENTYPE
 
+// printf-like wrapper around fbink_print_ot ;).
+int
+	fbink_printf_ot(int fbfd	UNUSED_BY_MINIMAL,
+			FBInkOTConfig* cfg  UNUSED_BY_MINIMAL,
+			FBInkConfig* fbCfg  UNUSED_BY_MINIMAL,
+			const char* fmt     UNUSED_BY_MINIMAL, 
+			...                 UNUSED_BY_MINIMAL)
+{
+#ifdef FBINK_WITH_OPENTYPE
+	// We'll need to store our formatted string somewhere...
+	// NOTE: Unlike fbink_printf, we can't assume a maximum size, so we set the buffer size to the input
+	//       string size, and realloc if we must (which is likely).
+	char* buffer = NULL;
+	size_t buffer_size = strlen(fmt) + 1U;
+	// NOTE: We use calloc to make sure it'll always be zero-initialized,
+	//       and the OS is smart enough to make it fast if we don't use the full space anyway (CoW zeroing).
+	buffer = calloc(buffer_size, sizeof(*buffer));
+	if (buffer == NULL) {
+		char  buf[256];
+		char* errstr = strerror_r(errno, buf, sizeof(buf));
+		WARN("calloc (page): %s", errstr);
+		return ERRCODE(EXIT_FAILURE);
+	}
+
+	va_list args;
+	va_start(args, fmt);
+	// vsnprintf will ensure we'll always be NULL-terminated (but not NULL-backfilled, hence calloc!) ;).
+	int size = vsnprintf(buffer, buffer_size, fmt, args);
+	// vsnprintf will tell us if it truncated our string to fit the buffer, and by how much. We will need
+	// to realloc if this occurs.
+	if (size >= 0 && (size_t)size >= buffer_size) {
+		char* tmp_buf = NULL;
+		size_t new_size = (size_t)size + 4U; // Just to be extra safe, use a wide null terminator
+		tmp_buf = realloc(buffer, new_size);
+		if (tmp_buf == NULL) {
+			free(buffer);
+			char  buf[256];
+			char* errstr = strerror_r(errno, buf, sizeof(buf));
+			WARN("realloc (page): %s", errstr);
+			return ERRCODE(EXIT_FAILURE);
+		}
+		buffer = tmp_buf;
+		tmp_buf = NULL;
+		// Memset the new buffer, because realloc doesn't
+		memset(buffer, '\0', new_size);
+		// Finally, we call vsnprintf() again, this time with the new buffer that should fit our formatted string
+		vsnprintf(buffer, new_size, fmt, args);
+	// We may as well check for an error from vsnprintf() while we're at it.
+	} else if (size < 0) {
+		free(buffer);
+		WARN("Could not format string");
+		return ERRCODE(EXIT_FAILURE);
+	}
+	va_end(args);
+
+	int rv = fbink_print_ot(fbfd, buffer, cfg, fbCfg);
+	// Cleanup
+	free(buffer);
+	return rv;
+#else
+	WARN("OpenType support is disabled in this FBInk build");
+	return ERRCODE(ENOSYS);
+#endif    // FBINK_WITH_OPENTYPE
+}
 int
     fbink_print_ot(int fbfd    UNUSED_BY_MINIMAL,
 		   const char* string UNUSED_BY_MINIMAL,

--- a/fbink.h
+++ b/fbink.h
@@ -299,6 +299,14 @@ FBINK_API int fbink_printf(int fbfd, const FBInkConfig* fbink_config, const char
 //       As such, it only makes sense in the context of a single, specific print call.
 FBINK_API int fbink_print_ot(int fbfd, const char* string, FBInkOTConfig* cfg, FBInkConfig* fbCfg);
 
+// Like fbink_print_ot, but with printf formatting ;).
+// fbfd:		open file descriptor to the framebuffer character device,
+//				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call
+// cfg:			Pointer to a FBInkOTConfig struct.
+// fbCfg:		Optional pointer to a FBInkConfig struct.
+FBINK_API int fbink_printf_ot(int fbfd, FBInkOTConfig* cfg, FBInkConfig* fbCfg, const char* fmt, ...)
+	__attribute__((format(printf, 4, 5)));
+
 // A simple wrapper around the internal screen refresh handling, without requiring you to include einkfb/mxcfb headers
 // fbfd:		open file descriptor to the framebuffer character device,
 //				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call


### PR DESCRIPTION
No great hurry on this, since I missed 1.8.1 (and didn't start working on it untill afterwards anyway)

I thought OT/TT users might like to join in on the printf fun, so I implemented that.

Unfortunately, I couldn't reuse `fbink_printf` as-is, because of the assumptions made regarding buffer lengths. `fbink_printf_ot` mostly copies `fbink_printf`, except for the fact I set the initial buffer size to the input string size, and reallocate if necessary.

I have to do this because there is no easily defined maximum number of characters to print at this stage. We only gain that information during the measurement phase of `fbink_print_ot`.

Tested to be working alright on my Kobo (in English at least), including mixing format flags, and our markdown syntax. `vsnprintf` only cares about the asterisk in the context of a format flag, which then gets removed in the output, so our md parser won't see it. At least, that's how I *think* it works...