### PR TITLE
add a script to build debian packages & use it for Cervantes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,7 @@ linux:
 
 cervantes:
 	$(MAKE) strip CERVANTES=true
+	./tools/do_debian_package.sh $(OUT_DIR) armel
 
 kobo: release
 	mkdir -p Kobo/usr/local/fbink/bin Kobo/usr/bin Kobo/usr/local/fbink/lib Kobo/usr/local/fbink/include

--- a/tools/do_debian_package.sh
+++ b/tools/do_debian_package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Script to generate debian packages for FBInk. 
+# Script to generate debian packages for FBInk.
 PACKAGE="FBInk"
 AUTHOR="NiLuJe <niluje@gmail.com>"
 DESC_1="FrameBuffer eInker"
@@ -18,9 +18,10 @@ BIN_PATH="${PKG_PATH}/usr/bin"
 DEB_PATH="${PKG_PATH}/DEBIAN"
 CONTROL="${DEB_PATH}/control"
 
-# Get version from git if posible. Fallback to a known version ;p
+# Get version from git if posible. Fallback to defined FBINK_VERSION
 # Note: version string must start with a number
-VERSION="$(git describe 2>/dev/null | sed 's/[^0-9]*//' || echo '1.9.0')"
+FALLBACK_VERSION="$(grep 'define FBINK_VERSION' fbink_internal.h | cut -f2 -d\" | cut -f2 -dv)"
+VERSION="$(git describe 2>/dev/null | sed 's/[^0-9]*//' || echo ${FALLBACK_VERSION})"
 
 # package name
 FULL_NAME="${PACKAGE}-${VERSION}-${TARGET_ARCH}.deb"

--- a/tools/do_debian_package.sh
+++ b/tools/do_debian_package.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+
+# Script to generate debian packages for FBInk. 
+PACKAGE="FBInk"
+AUTHOR="NiLuJe <niluje@gmail.com>"
+DESC_1="FrameBuffer eInker"
+DESC_2="a small tool to print text and images to an eInk Linux framebuffer."
+
+# Call this file from Makefile -------
+# Use $(OUT_DIR) as the first argument
+# and target arch as the second argument.
+ROOTFS_BASE="${1}"
+TARGET_ARCH="${2}"
+
+# Temp stuff.
+PKG_PATH="${ROOTFS_BASE}/pkg"
+BIN_PATH="${PKG_PATH}/usr/bin"
+DEB_PATH="${PKG_PATH}/DEBIAN"
+CONTROL="${DEB_PATH}/control"
+
+# Get version from git if posible. Fallback to a known version ;p
+# Note: version string must start with a number
+VERSION="$(git describe 2>/dev/null | sed 's/[^0-9]*//' || echo '1.9.0')"
+
+# package name
+FULL_NAME="${PACKAGE}-${VERSION}-${TARGET_ARCH}.deb"
+
+command_exists () {
+  type "$1" >/dev/null 2>/dev/null
+}
+
+# Run only if dpkg-deb exists
+COMMAND="dpkg-deb"
+if command_exists "$COMMAND"; then
+    echo "Building ${FULL_NAME}"
+    mkdir -p ${BIN_PATH} ${DEB_PATH}
+    echo "Package: ${PACKAGE}" > "$CONTROL"
+    echo "Version: ${VERSION}" >> "$CONTROL"
+    echo "Section: base" >> "$CONTROL"
+    echo "Priority: optional" >> "$CONTROL"
+    echo "Architecture: ${TARGET_ARCH}" >> "$CONTROL"
+    echo "Maintainer: ${AUTHOR}" >> "$CONTROL"
+    echo "Description: ${DESC_1}" >> "$CONTROL"
+    echo " ${DESC_2}" >> "$CONTROL"
+    cp -p ${ROOTFS_BASE}/fbink ${BIN_PATH}
+    dpkg-deb -b ${PKG_PATH} ${ROOTFS_BASE}/${FULL_NAME}
+    rm -rf ${PKG_PATH}
+else
+    echo "${COMMAND} not found, skipping target ${FULL_NAME}"
+fi
+
+exit 0


### PR DESCRIPTION
It relies on `dpkg-deb` on `$PATH`. Intended for cervantes but should work as is for other targets and architectures.

Debian arch names != `uname -m`. More info on https://www.debian.org/ports/


This kind of package won't be accepted by Debian, of course,  but is a nice way to redistribute releases for supported targets :+1: 