### PR TITLE
Dump & Restore feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,8 @@ utils: outdir
 	$(STRIP) --strip-unneeded $(OUT_DIR)/rota
 	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/fbdepth utils/fbdepth.c
 	$(STRIP) --strip-unneeded $(OUT_DIR)/fbdepth
+	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/dump utils/dump.c $(LIBS)
+	$(STRIP) --strip-unneeded $(OUT_DIR)/dump
 
 strip: static
 	$(MAKE) stripbin
@@ -465,6 +467,7 @@ clean:
 	rm -rf Release/button_scan
 	rm -rf Release/rota
 	rm -rf Release/fbdepth
+	rm -rf Release/dump
 	rm -rf Debug/*.a
 	rm -rf Debug/*.so*
 	rm -rf Debug/shared/*.o
@@ -480,6 +483,7 @@ clean:
 	rm -rf Debug/button_scan
 	rm -rf Debug/rota
 	rm -rf Debug/fbdepth
+	rm -rf Debug/dump
 
 distclean: clean libunibreakclean
 	rm -rf LibUniBreakBuild

--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,8 @@ utils: outdir
 	$(STRIP) --strip-unneeded $(OUT_DIR)/rota
 	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/fbdepth utils/fbdepth.c
 	$(STRIP) --strip-unneeded $(OUT_DIR)/fbdepth
+
+dump: static
 	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/dump utils/dump.c $(LIBS)
 	$(STRIP) --strip-unneeded $(OUT_DIR)/dump
 
@@ -489,4 +491,4 @@ distclean: clean libunibreakclean
 	rm -rf LibUniBreakBuild
 	rm -rf libunibreak.built
 
-.PHONY: default outdir all staticlib sharedlib static shared striplib striparchive stripbin strip debug static pic shared release kindle legacy cervantes linux armcheck kobo libunibreakclean utils clean distclean
+.PHONY: default outdir all staticlib sharedlib static shared striplib striparchive stripbin strip debug static pic shared release kindle legacy cervantes linux armcheck kobo libunibreakclean utils dump clean distclean

--- a/fbink.c
+++ b/fbink.c
@@ -6188,12 +6188,12 @@ int
 		// Align to the nearest byte boundary to make our life easier...
 		if (region.left & 0x01) {
 			// x is odd, round *down* to the nearest multiple of two (i.e., align to the start of the current byte)
-			region.left &= ~0x01;
+			region.left &= ~0x01u;
 			LOG("Updated region.left to %u because of alignment constraints", region.left);
 		}
 		if (region.width & 0x01) {
 			// w is odd, round *up* to the nearest multiple of two (i.e., align to the end of the current byte)
-			region.width = (region.width + 1) & ~0x01;
+			region.width = (region.width + 1) & ~0x01u;
 			LOG("Updated region.width to %u because of alignment constraints", region.width);
 		}
 		// Two pixels per byte, and we've just ensured to never end up with a decimal when dividing by two ;).

--- a/fbink.c
+++ b/fbink.c
@@ -6084,6 +6084,19 @@ int
 		// Full dump, easy enough
 		memcpy(fbPtr, dump->data, fInfo.line_length * vInfo.yres);
 		fullscreen_region(&region);
+	} else {
+		// Region dump, restore line by line
+		// FIXME: 4bpp?
+		uint8_t bpp = dump->bpp / 8U;
+		for (unsigned short int j = dump->y, l = 0U; j < dump->y + dump->h; j++, l++) {
+			size_t fb_offset   = (uint32_t)(dump->x * bpp) + (j * fInfo.line_length);
+			size_t dump_offset = l * (dump->w * bpp);
+			memcpy(fbPtr + fb_offset, dump->data + dump_offset, dump->w * bpp);
+		}
+		region.left   = dump->x;
+		region.top    = dump->y;
+		region.width  = dump->w;
+		region.height = dump->h;
 	}
 
 	// And now, we can refresh the screen

--- a/fbink.c
+++ b/fbink.c
@@ -6139,21 +6139,12 @@ int
 	region.height = MIN(screenHeight - region.top, (uint32_t) h);
 
 	// NOTE: If we ended up with negative display offsets, we should shave those off region.width & region.height,
-	//       when it makes sense to do so,
-	//       but we need to remember the unshaven value for the pixel loop condition,
-	//       to avoid looping on only part of the image.
-	unsigned short int max_width  = (unsigned short int) region.width;
-	unsigned short int max_height = (unsigned short int) region.height;
-	// NOTE: We also need to decide if we start looping at the top left of the image, or if we start later, to
-	//       avoid plotting off-screen pixels when using negative display offsets...
+	//       when it makes sense to do so.
 	unsigned short int img_x_off = 0;
 	unsigned short int img_y_off = 0;
 	if (x_off < 0) {
 		// We'll start plotting from the beginning of the *visible* part of the image ;)
 		img_x_off = (unsigned short int) (abs(x_off) + viewHoriOrigin);
-		max_width = (unsigned short int) (max_width + img_x_off);
-		// Make sure we're not trying to loop past the actual width of the image!
-		max_width = (unsigned short int) MIN(w, max_width);
 		// Only if the visible section of the image's width is smaller than our screen's width...
 		if ((uint32_t)(w - img_x_off) < viewWidth) {
 			region.width -= img_x_off;
@@ -6166,20 +6157,17 @@ int
 		} else {
 			img_y_off = (unsigned short int) (abs(y_off) + viewVertOrigin);
 		}
-		max_height = (unsigned short int) (max_height + img_y_off);
-		// Make sure we're not trying to loop past the actual height of the image!
-		max_height = (unsigned short int) MIN(h, max_height);
 		// Only if the visible section of the image's height is smaller than our screen's height...
 		if ((uint32_t)(h - img_y_off) < viewHeight) {
 			region.height -= img_y_off;
 		}
 	}
 	LOG("Region: top=%u, left=%u, width=%u, height=%u", region.top, region.left, region.width, region.height);
-	LOG("Dump becomes visible @ (%hu, %hu) for (%hu, %hu) out of %dx%d pixels",
+	LOG("Dump becomes visible @ (%hu, %hu) for %ux%u out of the requested %dx%d pixels",
 	    img_x_off,
 	    img_y_off,
-	    max_width,
-	    max_height,
+	    region.width,
+	    region.height,
 	    w,
 	    h);
 

--- a/fbink.c
+++ b/fbink.c
@@ -5490,7 +5490,8 @@ static int
 				size_t fb_offset;
 				for (j = img_y_off; j < max_height; j++) {
 					pix_offset = (size_t)((j * w) + img_x_off);
-					fb_offset  = (size_t)((j + y_off) * fInfo.line_length) + (img_x_off + x_off);
+					fb_offset  = ((uint32_t)(j + y_off) * fInfo.line_length) +
+						    (unsigned int) (img_x_off + x_off);
 					memcpy(fbPtr + fb_offset, data + pix_offset, max_width);
 				}
 			} else {

--- a/fbink.c
+++ b/fbink.c
@@ -6088,7 +6088,7 @@ int
 		// Region dump, restore line by line
 		// FIXME: 4bpp?
 		uint8_t bpp = dump->bpp / 8U;
-		for (unsigned short int j = dump->y, l = 0U; j < dump->y + dump->h; j++, l++) {
+		for (unsigned short int j = dump->y, l = 0U; l < dump->h; j++, l++) {
 			size_t fb_offset   = (uint32_t)(dump->x * bpp) + (j * fInfo.line_length);
 			size_t dump_offset = l * (dump->w * bpp);
 			memcpy(fbPtr + fb_offset, dump->data + dump_offset, dump->w * bpp);

--- a/fbink.c
+++ b/fbink.c
@@ -6062,7 +6062,7 @@ int
 
 	// Dump a region of the fb
 	// Pilfer the coordinates computations from draw_image ;).
-	// NOTE: We compute initial offsets from row/col, to help aligning images with text.
+	// NOTE: We compute initial offsets from row/col, to help aligning the region with text.
 	if (fbink_cfg->col < 0) {
 		x_off = (short int) (viewHoriOrigin + x_off + (MAX(MAXCOLS + fbink_cfg->col, 0) * FONTW));
 	} else {
@@ -6070,7 +6070,7 @@ int
 	}
 	// NOTE: Unless we *actually* specified a row, ignore viewVertOffset
 	//       The rationale being we want to keep being aligned to text rows when we do specify a row,
-	//       but we don't want the extra offset when we don't (in particular, when printing full-screen images).
+	//       but we don't want the extra offset when we don't (in particular, when dumping what amounts to the full screen).
 	// NOTE: This means that row 0 and row -MAXROWS *will* behave differently, but so be it...
 	if (fbink_cfg->row < 0) {
 		y_off = (short int) (viewVertOrigin + y_off + (MAX(MAXROWS + fbink_cfg->row, 0) * FONTH));
@@ -6078,7 +6078,7 @@ int
 		y_off = (short int) (viewVertOrigin - viewVertOffset + y_off + (fbink_cfg->row * FONTH));
 		// This of course means that row 0 effectively breaks that "align with text" contract if viewVertOffset != 0,
 		// on the off-chance we do explicitly really want to align something to row 0, so, warn about it...
-		// The "print full-screen images" use-case is greatly more prevalent than "actually rely on row 0 alignment" ;).
+		// The "print full-screen data" use-case is greatly more prevalent than "actually rely on row 0 alignment" ;).
 		// And in case that's *really* needed, using -MAXROWS instead of 0 will honor alignment anyway.
 		if (viewVertOffset != 0U) {
 			LOG("Ignoring the %hhupx row offset because row is 0!", viewVertOffset);
@@ -6143,21 +6143,21 @@ int
 	unsigned short int img_x_off = 0;
 	unsigned short int img_y_off = 0;
 	if (x_off < 0) {
-		// We'll start plotting from the beginning of the *visible* part of the image ;)
+		// We'll start dumping from the beginning of the *visible* part of the region ;)
 		img_x_off = (unsigned short int) (abs(x_off) + viewHoriOrigin);
-		// Only if the visible section of the image's width is smaller than our screen's width...
+		// Only if the visible section of the region's width is smaller than our screen's width...
 		if ((uint32_t)(w - img_x_off) < viewWidth) {
 			region.width -= img_x_off;
 		}
 	}
 	if (y_off < 0) {
-		// We'll start plotting from the beginning of the *visible* part of the image ;)
+		// We'll start dumping from the beginning of the *visible* part of the region ;)
 		if (fbink_cfg->row == 0) {
 			img_y_off = (unsigned short int) (abs(y_off) + viewVertOrigin - viewVertOffset);
 		} else {
 			img_y_off = (unsigned short int) (abs(y_off) + viewVertOrigin);
 		}
-		// Only if the visible section of the image's height is smaller than our screen's height...
+		// Only if the visible section of the region's height is smaller than our screen's height...
 		if ((uint32_t)(h - img_y_off) < viewHeight) {
 			region.height -= img_y_off;
 		}

--- a/fbink.c
+++ b/fbink.c
@@ -6260,7 +6260,7 @@ cleanup:
 
 // Restore a fb dump
 int
-    fbink_restore(int fbfd, const FBInkConfig* fbink_cfg, FBInkDump* dump)
+    fbink_restore(int fbfd, const FBInkConfig* fbink_cfg, const FBInkDump* dump)
 {
 #ifdef FBINK_WITH_IMAGE
 	// Open the framebuffer if need be...

--- a/fbink.c
+++ b/fbink.c
@@ -567,7 +567,7 @@ static void
 	//       Anyway, don't clobber that, as it seems to cause softlocks on BQ/Cervantes,
 	//       and be very conservative, using yres instead of yres_virtual, as Qt *may* already rely on that memory region.
 	if (vInfo.bits_per_pixel == 16) {
-		memset(fbPtr, v, fInfo.line_length * vInfo.yres);
+		memset(fbPtr, v, (size_t)(fInfo.line_length * vInfo.yres));
 	} else {
 		// NOTE: fInfo.smem_len should actually match fInfo.line_length * vInfo.yres_virtual on 32bpp ;).
 		//       Which is how things should always be, but, alas, poor Yorick...
@@ -6007,7 +6007,7 @@ int
 		dump->data = NULL;
 	}
 	// Start by allocating enough memory for a full dump of the visible screen...
-	dump->data = calloc(fInfo.line_length * vInfo.yres, sizeof(*dump->data));
+	dump->data = calloc((size_t)(fInfo.line_length * vInfo.yres), sizeof(*dump->data));
 	if (dump->data == NULL) {
 		char  buf[256];
 		char* errstr = strerror_r(errno, buf, sizeof(buf));
@@ -6024,7 +6024,7 @@ int
 	dump->h       = (unsigned short int) vInfo.yres;
 	dump->is_full = true;
 	// And finally, the fb data itself
-	memcpy(dump->data, fbPtr, fInfo.line_length * vInfo.yres);
+	memcpy(dump->data, fbPtr, (size_t)(fInfo.line_length * vInfo.yres));
 
 	// Cleanup
 cleanup:
@@ -6208,9 +6208,9 @@ int
 			LOG("Updated region.width to %u because of alignment constraints", region.width);
 		}
 		// Two pixels per byte, and we've just ensured to never end up with a decimal when dividing by two ;).
-		dump->data = calloc((region.width >> 1) * region.height, sizeof(*dump->data));
+		dump->data = calloc((size_t)((region.width >> 1) * region.height), sizeof(*dump->data));
 	} else {
-		dump->data = calloc((region.width * bpp) * region.height, sizeof(*dump->data));
+		dump->data = calloc((size_t)((region.width * bpp) * region.height), sizeof(*dump->data));
 	}
 	if (dump->data == NULL) {
 		char  buf[256];
@@ -6309,7 +6309,7 @@ int
 
 	if (dump->is_full) {
 		// Full dump, easy enough
-		memcpy(fbPtr, dump->data, fInfo.line_length * vInfo.yres);
+		memcpy(fbPtr, dump->data, (size_t)(fInfo.line_length * vInfo.yres));
 		fullscreen_region(&region);
 	} else {
 		// Region dump, restore line by line

--- a/fbink.c
+++ b/fbink.c
@@ -6086,12 +6086,13 @@ int
 		fullscreen_region(&region);
 	} else {
 		// Region dump, restore line by line
-		// FIXME: 4bpp?
+		// We're going to need the amount of bytes taken per pixel...
+		// FIXME: 4bpp handling...
 		uint8_t bpp = dump->bpp / 8U;
 		for (unsigned short int j = dump->y, l = 0U; l < dump->h; j++, l++) {
-			size_t fb_offset   = (uint32_t)(dump->x * bpp) + (j * fInfo.line_length);
-			size_t dump_offset = l * (dump->w * bpp);
-			memcpy(fbPtr + fb_offset, dump->data + dump_offset, dump->w * bpp);
+			size_t fb_offset   = (size_t)(dump->x * bpp) + (j * fInfo.line_length);
+			size_t dump_offset = (size_t)(l * (dump->w * bpp));
+			memcpy(fbPtr + fb_offset, dump->data + dump_offset, (size_t) dump->w * bpp);
 		}
 		region.left   = dump->x;
 		region.top    = dump->y;

--- a/fbink.c
+++ b/fbink.c
@@ -6171,6 +6171,9 @@ int
 	    w,
 	    h);
 
+	// Rotate the region if need be...
+	(*fxpRotateRegion)(&region);
+
 	// Free current data in case the dump struct is being reused
 	if (dump->data) {
 		LOG("Recycling FBinkDump!");
@@ -6321,15 +6324,6 @@ int
 	}
 
 	// And now, we can refresh the screen
-	// Rotate the region if need be...
-	(*fxpRotateRegion)(&region);
-
-	// Fudge the region if we asked for a screen clear, so that we actually refresh the full screen...
-	if (fbink_cfg->is_cleared) {
-		fullscreen_region(&region);
-	}
-
-	// Refresh screen
 	if (refresh(fbfd,
 		    region,
 		    get_wfm_mode(fbink_cfg->wfm_mode),

--- a/fbink.h
+++ b/fbink.h
@@ -520,6 +520,7 @@ FBINK_API int fbink_dump(int fbfd, const FBInkConfig* fbink_cfg, FBInkDump* dump
 // Returns -(ENOSYS) when image support is disabled (MINIMAL build)
 // Otherwise, returns a few different things on failure:
 //	-(ENOTSUP)	when the current rotation or bitdepth doesn't match the dump's
+//	-(EINVAL)	when there's no data to restore
 FBINK_API int fbink_restore(int fbfd, const FBInkConfig* fbink_cfg, FBInkDump* dump);
 
 // Scan the screen for Kobo's "Connect" button in the "USB plugged in" popup,

--- a/fbink.h
+++ b/fbink.h
@@ -556,7 +556,7 @@ FBINK_API int fbink_region_dump(int                fbfd,
 // NOTE: In case the dump was regional, it will be restored in the exact same coordinates it was taken from,
 //       no actual positioning is needed/supported at restore time.
 // NOTE: This does *NOT* free data.dump!
-FBINK_API int fbink_restore(int fbfd, const FBInkConfig* fbink_cfg, FBInkDump* dump);
+FBINK_API int fbink_restore(int fbfd, const FBInkConfig* fbink_cfg, const FBInkDump* dump);
 
 // Scan the screen for Kobo's "Connect" button in the "USB plugged in" popup,
 // and optionally generate an input event to press that button.

--- a/fbink.h
+++ b/fbink.h
@@ -237,11 +237,12 @@ typedef struct
 	bool      is_verbose;      // Print verbose diagnostic informations on stdout
 	bool      is_quiet;        // Hide fbink_init()'s hardware setup info (sent to stderr)
 	bool      ignore_alpha;    // Ignore any potential alpha channel in source image (i.e., flatten the image)
-	uint8_t   halign;      // Horizontal alignment of images (NONE/LEFT, CENTER, EDGE/RIGHT; c.f., ALIGN_INDEX_T enum)
-	uint8_t   valign;      // Vertical alignment of images (NONE/TOP, CENTER, EDGE/BOTTOM; c.f., ALIGN_INDEX_T enum)
-	uint8_t   wfm_mode;    // Request a specific waveform mode when printing an image (c.f., WFM_MODE_INDEX_T enum)
-	bool      is_dithered;    // Request (ordered) hardware dithering (if supported).
-	bool      no_refresh;     // Skip actually refreshing the eInk screen (useful when drawing in batch)
+	uint8_t   halign;    // Horizontal alignment of images (NONE/LEFT, CENTER, EDGE/RIGHT; c.f., ALIGN_INDEX_T enum)
+	uint8_t   valign;    // Vertical alignment of images (NONE/TOP, CENTER, EDGE/BOTTOM; c.f., ALIGN_INDEX_T enum)
+	uint8_t
+	     wfm_mode;    // Request a specific waveform mode when printing an image or dump (c.f., WFM_MODE_INDEX_T enum)
+	bool is_dithered;    // Request (ordered) hardware dithering (if supported).
+	bool no_refresh;     // Skip actually refreshing the eInk screen (useful when drawing in batch)
 } FBInkConfig;
 
 typedef struct
@@ -257,6 +258,18 @@ typedef struct
 	bool               is_centered;     // Horizontal centering
 	bool               is_formatted;    // Is string "formatted"? Bold/Italic support only, markdown like syntax
 } FBInkOTConfig;
+
+typedef struct
+{
+	uint8_t            rota;
+	uint8_t            bpp;
+	unsigned short int x;
+	unsigned short int y;
+	unsigned short int w;
+	unsigned short int h;
+	unsigned char*     data;
+	bool               is_full;
+} FBInkDump;
 
 // NOTE: Unless otherwise specified,
 //       stuff returns a negative value (usually -(EXIT_FAILURE)) on failure & EXIT_SUCCESS otherwise ;).
@@ -498,6 +511,16 @@ FBINK_API int fbink_print_raw_data(int                fbfd,
 //				if set to FBFD_AUTO, the fb is opened & mmap'ed for the duration of this call
 // fbink_cfg:		Pointer to an FBInkConfig struct (honors is_flashing, is_inverted, is_dithered, no_refresh, pen_*_color)
 FBINK_API int fbink_cls(int fbfd, const FBInkConfig* fbink_cfg);
+
+// Dump fb
+// Returns -(ENOSYS) when image support is disabled (MINIMAL build)
+FBINK_API int fbink_dump(int fbfd, const FBInkConfig* fbink_cfg, FBInkDump* dump);
+
+// Restore fb
+// Returns -(ENOSYS) when image support is disabled (MINIMAL build)
+// Otherwise, returns a few different things on failure:
+//	-(ENOTSUP)	when the current rotation or bitdepth doesn't match the dump's
+FBINK_API int fbink_restore(int fbfd, const FBInkConfig* fbink_cfg, FBInkDump* dump);
 
 // Scan the screen for Kobo's "Connect" button in the "USB plugged in" popup,
 // and optionally generate an input event to press that button.

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -29,23 +29,27 @@ static bool
 {
 	switch (dev) {
 		case 0x01:    // K1
+			deviceQuirks.isKindleLegacy = true;
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.deviceName, "1", sizeof(deviceQuirks.deviceName) - 1U);
 			return true;
 		case 0x02:    // K2
 		case 0x03:
+			deviceQuirks.isKindleLegacy = true;
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.deviceName, "2", sizeof(deviceQuirks.deviceName) - 1U);
 			return true;
 		case 0x04:    // KDX
 		case 0x05:
 		case 0x09:
+			deviceQuirks.isKindleLegacy = true;
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.deviceName, "DX", sizeof(deviceQuirks.deviceName) - 1U);
 			return true;
 		case 0x08:    // K3
 		case 0x06:
 		case 0x0A:
+			deviceQuirks.isKindleLegacy = true;
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.deviceName, "3", sizeof(deviceQuirks.deviceName) - 1U);
 			return true;

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -391,6 +391,7 @@ static void
 				break;
 			default:
 				WARN("Unidentified Cervantes device (%hhu)", config.pcb_id);
+				// Flawfinder: ignore
 				strncpy(deviceQuirks.deviceName, "Unknown!", sizeof(deviceQuirks.deviceName) - 1U);
 				break;
 		}

--- a/ffi/fbink_decl.c
+++ b/ffi/fbink_decl.c
@@ -20,12 +20,16 @@ cdecl_type(BG_COLOR_INDEX_T)
 cdecl_type(WFM_MODE_INDEX_T)
 cdecl_type(HW_DITHER_INDEX_T)
 
+cdecl_type(NTX_ROTA_INDEX_T)
+
 // Config structs
 cdecl_type(FBInkState)
 
 cdecl_type(FBInkConfig)
 
 cdecl_type(FBInkOTConfig)
+
+cdecl_type(FBInkDump)
 
 // API
 cdecl_func(fbink_version)
@@ -56,6 +60,10 @@ cdecl_func(fbink_print_image)
 cdecl_func(fbink_print_raw_data)
 
 cdecl_func(fbink_cls)
+
+cdecl_func(fbink_dump)
+cdecl_func(fbink_region_dump)
+cdecl_func(fbink_restore)
 
 cdecl_func(fbink_button_scan)
 cdecl_func(fbink_wait_for_usbms_processing)

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -113,6 +113,8 @@ int
 cleanup:
 	// Free potential dump data...
 	free(dump.data);
+	// Don't leave it dangling so it doesn't get flagged as recyclable.
+	dump.data = NULL;
 
 	if (fbink_close(fbfd) == ERRCODE(EXIT_FAILURE)) {
 		fprintf(stderr, "Failed to close the framebuffer, aborting . . .\n");

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -89,7 +89,7 @@ int
 	// Dump a region at the center of the screen
 	fbink_cfg.halign = CENTER;
 	fbink_cfg.valign = CENTER;
-	if (fbink_region_dump(fbfd, 0, 0, 500, 250, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+	if (fbink_region_dump(fbfd, -650, -50, 500, 250, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
 		fprintf(stderr, "Failed to dump fb region, aborting . . .\n");
 		rv = ERRCODE(EXIT_FAILURE);
 		goto cleanup;

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -89,7 +89,7 @@ int
 	// Dump a region at the center of the screen
 	fbink_cfg.halign = CENTER;
 	fbink_cfg.valign = CENTER;
-	if (fbink_region_dump(fbfd, -650, -50, 500, 250, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+	if (fbink_region_dump(fbfd, -650, -50, 501, 250, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
 		fprintf(stderr, "Failed to dump fb region, aborting . . .\n");
 		rv = ERRCODE(EXIT_FAILURE);
 		goto cleanup;

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -19,6 +19,7 @@
 */
 
 // NOTE: Fairly useless piece of code basically just there to test the dump/restore functionality ;).
+//       We could arguably plug into stb_image_write to basically reimplement fbgrab...
 
 // Because we're pretty much Linux-bound ;).
 #ifndef _GNU_SOURCE
@@ -39,6 +40,8 @@ int
 	FBInkConfig fbink_cfg = { 0 };
 	FBInkDump   dump      = { 0 };
 	fbink_cfg.is_verbose  = true;
+	// Flash to make stuff more obvious
+	fbink_cfg.is_flashing = true;
 
 	// Assume success, until shit happens ;)
 	int rv = EXIT_SUCCESS;

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -61,7 +61,7 @@ int
 	}
 
 	// Dump
-	if (fbink_dump(fbfd, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+	if (fbink_dump(fbfd, &dump) != ERRCODE(EXIT_SUCCESS)) {
 		fprintf(stderr, "Failed to dump fb, aborting . . .\n");
 		rv = ERRCODE(EXIT_FAILURE);
 		goto cleanup;

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -71,6 +71,8 @@ int
 	fbink_cfg.is_centered = true;
 	fbink_cfg.is_padded   = true;
 	fbink_cfg.is_halfway  = true;
+	// Inverted to make region restore easier to spot
+	fbink_cfg.is_inverted = true;
 	if (fbink_print(fbfd, "Wheeee!", &fbink_cfg) < 0) {
 		fprintf(stderr, "Failed to print!\n");
 		rv = ERRCODE(EXIT_FAILURE);
@@ -78,6 +80,29 @@ int
 	}
 
 	// Restore
+	if (fbink_restore(fbfd, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+		fprintf(stderr, "Failed to restore fb, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Dump a region at the center of the screen
+	fbink_cfg.halign = CENTER;
+	fbink_cfg.valign = CENTER;
+	if (fbink_region_dump(fbfd, 0, 0, 500, 250, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+		fprintf(stderr, "Failed to dump fb region, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Print random crap, again
+	if (fbink_print(fbfd, "Wheeee!", &fbink_cfg) < 0) {
+		fprintf(stderr, "Failed to print!\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Restore, again
 	if (fbink_restore(fbfd, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
 		fprintf(stderr, "Failed to restore fb, aborting . . .\n");
 		rv = ERRCODE(EXIT_FAILURE);

--- a/utils/dump.c
+++ b/utils/dump.c
@@ -1,0 +1,95 @@
+/*
+	FBInk: FrameBuffer eInker, a tool to print text & images on eInk devices (Kobo/Kindle)
+	Copyright (C) 2018-2019 NiLuJe <ninuje@gmail.com>
+
+	----
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as
+	published by the Free Software Foundation, either version 3 of the
+	License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// NOTE: Fairly useless piece of code basically just there to test the dump/restore functionality ;).
+
+// Because we're pretty much Linux-bound ;).
+#ifndef _GNU_SOURCE
+#	define _GNU_SOURCE
+#endif
+
+#include "../fbink.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+// We want to return negative values on failure, always
+#define ERRCODE(e) (-(e))
+
+int
+    main(void)
+{
+	// Setup FBInk
+	FBInkConfig fbink_cfg = { 0 };
+	FBInkDump   dump      = { 0 };
+	fbink_cfg.is_verbose  = true;
+
+	// Assume success, until shit happens ;)
+	int rv = EXIT_SUCCESS;
+
+	// Init FBInk
+	int fbfd = -1;
+	// Open framebuffer and keep it around, then setup globals.
+	if (ERRCODE(EXIT_FAILURE) == (fbfd = fbink_open())) {
+		fprintf(stderr, "Failed to open the framebuffer, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+	if (fbink_init(fbfd, &fbink_cfg) == ERRCODE(EXIT_FAILURE)) {
+		fprintf(stderr, "Failed to initialize FBInk, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Dump
+	if (fbink_dump(fbfd, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+		fprintf(stderr, "Failed to dump fb, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Print random crap
+	fbink_cfg.is_centered = true;
+	fbink_cfg.is_padded   = true;
+	fbink_cfg.is_halfway  = true;
+	if (fbink_print(fbfd, "Wheeee!", &fbink_cfg) < 0) {
+		fprintf(stderr, "Failed to print!\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Restore
+	if (fbink_restore(fbfd, &fbink_cfg, &dump) != ERRCODE(EXIT_SUCCESS)) {
+		fprintf(stderr, "Failed to restore fb, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+		goto cleanup;
+	}
+
+	// Cleanup
+cleanup:
+	// Free potential dump data...
+	free(dump.data);
+
+	if (fbink_close(fbfd) == ERRCODE(EXIT_FAILURE)) {
+		fprintf(stderr, "Failed to close the framebuffer, aborting . . .\n");
+		rv = ERRCODE(EXIT_FAILURE);
+	}
+
+	return rv;
+}


### PR DESCRIPTION
Basically, what was discussed in #31 (fix #31) ;).

Adds three new API calls:
`fbink_dump`, which dumps the *full* screen
`fbink_region_dump`, which dumps a specific region of the screen, supporting all the same crazy positioning options of the image printing code.
`fbink_restore`, which restores those two kinds of dumps, in the exact same coordinates they were taken from, and errors out if it can't (bitdepth or rotation mismatch between dump & restore time).

This requires a new struct:
`FBInkDump`, which holds a pointer to the FBInk-allocated storage, and the metadata it needs for the safety checks (i.e., coordinates, size, rota, bpp, is it full-screen).
Needs to be zero-initialized, and free'ing is left to the caller. Don't leave the data pointer dangling, otherwise the _dump functions will try to recycle the struct by freeing the data!
This means creating a single struct and keeping it around is perfectly valid, but it will only ever hold a single set of data, that from the latest dump call on it.