### PR TITLE
Some minor performance improvements

### DIFF
--- a/fbink.c
+++ b/fbink.c
@@ -125,6 +125,8 @@ static void
 		// ORed to avoid clobbering our even pixel
 		*((unsigned char*) (fbPtr + pix_offset)) |= (px->gray8 >> 4U);
 	}
+	// NOTE: This generally means artefacts happen if you don't start drawing on an even pixel,
+	//       and end drawing on an odd pixel...
 }
 
 static void
@@ -437,6 +439,7 @@ static void
 		//       One way to break that assumption is with an odd scaling factor:
 		//       In this case, using overlay mode in the fixed cell rendering codepath will lead to bogus edge colors,
 		//       (usually, on the left side).
+		//       See also the NOTE in put_pixel_Gray4...
 	}
 	// NOTE: c.f., FBInkPixel typedef in fbink_types.h for details on the union shenanigans...
 	//       In short: gray8 -> gray4.hi -> bgra.color.b

--- a/fbink.c
+++ b/fbink.c
@@ -991,7 +991,11 @@ static struct mxcfb_rect
 
 			// Get the glyph's pixmap (width <= 8 -> uint8_t)
 			const unsigned char* restrict bitmap = NULL;
+#ifdef FBINK_WITH_FONTS
 			bitmap                               = (*fxpFont8xGetBitmap)(ch);
+#else
+			bitmap                               = font8x8_get_bitmap(ch);
+#endif
 
 			// Crappy macro to avoid repeating myself in each branch...
 #define RENDER_GLYPH()                                                                                                   \

--- a/fbink.c
+++ b/fbink.c
@@ -574,6 +574,19 @@ static void
 				put_pixel_Gray4(&coords, px);
 			}
 		}
+	} else if (vInfo.bits_per_pixel == 16U && px->gray8 != 0x00 && px->gray8 != 0xFF) {
+		// Same thing @ 16bpp if we're not doing black or white, as those are the only colors in our palette
+		// that pack into two indentical bytes when packed as RGB565... -_-".
+		FBInkPixel packed_px;
+		packed_px.rgb565 = pack_rgb565(px->bgra.color.r, px->bgra.color.g, px->bgra.color.b);
+		for (unsigned short int cy = 0U; cy < h; cy++) {
+			for (unsigned short int cx = 0U; cx < w; cx++) {
+				FBInkCoordinates coords;
+				coords.x = (unsigned short int) (x + cx);
+				coords.y = (unsigned short int) (y + cy);
+				put_pixel_RGB565(&coords, &packed_px);
+			}
+		}
 	} else {
 		struct mxcfb_rect region = {
 			.top    = y,

--- a/fbink.c
+++ b/fbink.c
@@ -600,6 +600,7 @@ static void
 				FBInkCoordinates coords;
 				coords.x = (unsigned short int) (x + cx);
 				coords.y = (unsigned short int) (y + cy);
+				(*fxpRotateCoords)(&coords);
 				put_pixel_RGB565(&coords, &packed_px);
 			}
 		}
@@ -619,7 +620,7 @@ static void
 		}
 	}
 #ifdef DEBUG
-	LOG("Filled a %hux%hu rectangle @ (%hu, %hu)", w, h, x, y);
+	LOG("Filled a #%02hhX %hux%hu rectangle @ (%hu, %hu)", px->gray8, w, h, x, y);
 #endif
 }
 

--- a/fbink.c
+++ b/fbink.c
@@ -4927,6 +4927,10 @@ cleanup:
 int
     draw_progress_bars(int fbfd, bool is_infinite, uint8_t value, const FBInkConfig* restrict fbink_cfg)
 {
+	const uint8_t invert  = fbink_cfg->is_inverted ? 0xFF : 0U;
+	const uint8_t fgcolor = penFGColor ^ invert;
+	const uint8_t bgcolor = penBGColor ^ invert;
+
 	// Clear screen?
 	if (fbink_cfg->is_cleared) {
 		clear_screen(fbfd, bgcolor, fbink_cfg->is_flashing);
@@ -4938,8 +4942,6 @@ int
 	if (fbink_cfg->is_inverted) {
 		// NOTE: And, of course, RGB565 is terrible. Inverting the lossy packed value would be even lossier...
 		if (vInfo.bits_per_pixel == 16U) {
-			const uint8_t fgcolor = penFGColor ^ 0xFF;
-			const uint8_t bgcolor = penBGColor ^ 0xFF;
 			fgP.rgb565 = pack_rgb565(fgcolor, fgcolor, fgcolor);
 			bgP.rgb565 = pack_rgb565(bgcolor, bgcolor, bgcolor);
 		} else {
@@ -5001,8 +5003,8 @@ int
 			// NOTE: If we're using A2 refresh mode, we'll be enforcing monochrome anyway...
 			//       Making sure we do that on our end (... at least with default bg/fg colors anyway ;),
 			//       avoids weird behavior on devices where A2 can otherwise be quirky, like Kobo Mk. 7
-			emptyC  = fbink_cfg->is_inverted ? penBGColor ^ 0xFF : penBGColor;
-			borderC = fbink_cfg->is_inverted ? penFGColor ^ 0xFF : penFGColor;
+			emptyC  = bgcolor;
+			borderC = fgcolor;
 		} else {
 			emptyC  = fbink_cfg->is_inverted ? eInkFGCMap[BG_GRAYB] : eInkBGCMap[BG_GRAYB];
 			borderC = fbink_cfg->is_inverted ? eInkFGCMap[BG_GRAY4] : eInkBGCMap[BG_GRAY4];

--- a/fbink.c
+++ b/fbink.c
@@ -95,7 +95,7 @@ const char*
 }
 
 // #RGB -> RGB565
-static uint16_t
+static inline uint16_t
     pack_rgb565(uint8_t r, uint8_t g, uint8_t b)
 {
 	// ((r / 8) * 2048) + ((g / 4) * 32) + (b / 8);

--- a/fbink.c
+++ b/fbink.c
@@ -433,6 +433,10 @@ static void
 		// Odd pixel: low nibble
 		// We just have to point to what we got during the even pixel pass ;).
 		px->gray8 = px->gray4.lo;
+		// NOTE: Obviously, this behaves as expected only if there actually *was* a previous even pass...
+		//       One way to break that assumption is with an odd scaling factor:
+		//       In this case, using overlay mode in the fixed cell rendering codepath will lead to bogus edge colors,
+		//       (usually, on the left side).
 	}
 	// NOTE: c.f., FBInkPixel typedef in fbink_types.h for details on the union shenanigans...
 	//       In short: gray8 -> gray4.hi -> bgra.color.b

--- a/fbink.c
+++ b/fbink.c
@@ -344,10 +344,10 @@ static void
 //       (i.e., (*fxpPutPixel) is only marginally faster than put_pixel()),
 //       the overhead of going through the function pointers is rather large
 //       (i.e., put_pixel() can be twice as slow as put_pixel_*()).
-//       On our target HW, it's often slightly faster than branching or switching, though ;).
-//       On modern processors, branching should eventually take the lead, though,
-//       and in this case (ha!) appears to behave better than switching...
-//       Which is why we now branch via an if ladder.
+//       On the oldest of our target HW, it's often *slightly* faster than branching or switching, though ;).
+//       But on modern processors, even on our target HW, branching should eventually take the lead, though,
+//       and in this case (ha!) appears to behave *noticeably* better than switching...
+//       Which is why we now branch via an if ladder, as it should offer marginally better performance on newer devices.
 static void
     put_pixel(FBInkCoordinates coords, const FBInkPixel* restrict px, bool rgb565_packed)
 {

--- a/fbink.c
+++ b/fbink.c
@@ -98,6 +98,7 @@ const char*
 static uint16_t
     pack_rgb565(uint8_t r, uint8_t g, uint8_t b)
 {
+	// ((r / 8) * 2048) + ((g / 4) * 32) + (b / 8);
 	return (uint16_t)(((r >> 3U) << 11U) | ((g >> 2U) << 5U) | (b >> 3U));
 }
 
@@ -156,6 +157,7 @@ static void
 	// note: x * 4 as every pixel is 4 consecutive bytes
 	size_t pix_offset = (uint32_t)(coords->x << 2U) + (coords->y * fInfo.line_length);
 
+	// write the four bytes at once
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
 	*((uint32_t*) (fbPtr + pix_offset)) = px->bgra.p;
@@ -169,11 +171,7 @@ static void
 	// note: x * 2 as every pixel is 2 consecutive bytes
 	size_t pix_offset = (uint32_t)(coords->x << 1U) + (coords->y * fInfo.line_length);
 
-	// now this is about the same as 'fbp[pix_offset] = value'
-	// but a bit more complicated for RGB565
-	//uint16_t c = (uint16_t)(((color->r >> 3U) << 11U) | ((color->g >> 2U) << 5U) | (color->b >> 3U));
-	// or: c = ((r / 8) * 2048) + ((g / 4) * 32) + (b / 8);
-	// write 'two bytes at once', much to GCC's dismay...
+	// write the two bytes at once, much to GCC's dismay...
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
 	*((uint16_t*) (fbPtr + pix_offset)) = px->rgb565;

--- a/fbink.c
+++ b/fbink.c
@@ -4424,7 +4424,7 @@ int
 						    (uint8_t) DIV255((pmul_bg + ((fb_px.gray4.hi - bgcolor) * lnPtr[k])));
 						// Don't touch the low nibble...
 						pixel.gray4.lo = fb_px.gray4.lo;
-						put_pixel(paint_point, &pixel, true);
+						put_pixel(paint_point, &pixel, false);
 						paint_point.x++;
 					}
 					lnPtr += max_lw;
@@ -4472,7 +4472,7 @@ int
 						    (MUL255(fb_px.gray4.hi) + ((fgcolor - fb_px.gray4.hi) * lnPtr[k])));
 						// Don't touch the low nibble...
 						pixel.gray4.lo = fb_px.gray4.lo;
-						put_pixel(paint_point, &pixel, true);
+						put_pixel(paint_point, &pixel, false);
 						paint_point.x++;
 					}
 					lnPtr += max_lw;
@@ -4529,7 +4529,7 @@ int
 						     (((fb_px.gray4.hi ^ 0xFF) - fb_px.gray4.hi) * lnPtr[k])));
 						// Don't touch the low nibble...
 						pixel.gray4.lo = fb_px.gray4.lo;
-						put_pixel(paint_point, &pixel, true);
+						put_pixel(paint_point, &pixel, false);
 						paint_point.x++;
 					}
 					lnPtr += max_lw;

--- a/fbink.c
+++ b/fbink.c
@@ -1002,6 +1002,7 @@ static struct mxcfb_rect
 				/* Initial coordinates, before we generate the extra pixels from the scaling factor */   \
 				cx = (unsigned short int) (x_offs + i);                                                  \
 				cy = (unsigned short int) (y_offs + j);                                                  \
+				/* We already know the final pixel value, so we can take a shortcut w/ fill_rect :) */   \
 				fill_rect(cx, cy, FONTSIZE_MULT, FONTSIZE_MULT, pxC);                                    \
 			}                                                                                                \
 		}                                                                                                        \

--- a/fbink.c
+++ b/fbink.c
@@ -1033,19 +1033,18 @@ static struct mxcfb_rect
 			for (uint8_t x = 0U; x < glyphWidth; x++) {                                                      \
 				/* x: input column, i: first output column after scaling */                              \
 				i = (unsigned short int) (x * FONTSIZE_MULT);                                            \
-				/* Each element encodes a full row, we access a column's bit in that row by shifting. */ \
-				if (bitmap[y] & 1U << x) {                                                               \
-					/* bit was set, pixel is fg! */                                                  \
-					pxP = &fgP;                                                                      \
-				} else {                                                                                 \
-					/* bit was unset, pixel is bg */                                                 \
-					pxP = &bgP;                                                                      \
-				}                                                                                        \
 				/* Initial coordinates, before we generate the extra pixels from the scaling factor */   \
 				cx = (unsigned short int) (x_offs + i);                                                  \
 				cy = (unsigned short int) (y_offs + j);                                                  \
-				/* We already know the final pixel value, so we can take a shortcut w/ fill_rect :) */   \
-				fill_rect(cx, cy, FONTSIZE_MULT, FONTSIZE_MULT, pxP);                                    \
+				/* Each element encodes a full row, we access a column's bit in that row by shifting. */ \
+				if (bitmap[y] & 1U << x) {                                                               \
+					/* bit was set, pixel is fg! */                                                  \
+					/* Handle scaling by drawing a FONTSIZE_MULTpx square per pixel ;) */            \
+					fill_rect(cx, cy, FONTSIZE_MULT, FONTSIZE_MULT, &fgP);                           \
+				} else {                                                                                 \
+					/* bit was unset, pixel is bg */                                                 \
+					fill_rect(cx, cy, FONTSIZE_MULT, FONTSIZE_MULT, &bgP);                           \
+				}                                                                                        \
 			}                                                                                                \
 		}                                                                                                        \
 	} else {                                                                                                         \
@@ -4422,8 +4421,7 @@ int
 					for (unsigned int k = 0U; k < lw; k++) {
 						if (lnPtr[k] == 0xFF) {
 							// Full coverage (opaque) -> foreground
-							pixel = fgP;
-							put_pixel(paint_point, &pixel, true);
+							put_pixel(paint_point, &fgP, true);
 						} else if (lnPtr[k] != 0U) {
 							// AA, blend it using the coverage mask as alpha,
 							// and the underlying pixel as bg

--- a/fbink.c
+++ b/fbink.c
@@ -5084,6 +5084,7 @@ int
 			break;
 		case 24U:
 		case 32U:
+		default:
 			emptyP.bgra.color.a = 0xFF;
 			emptyP.bgra.color.r = emptyP.bgra.color.g = emptyP.bgra.color.b = emptyC;
 			borderP.bgra.color.a                                            = 0xFF;

--- a/fbink.c
+++ b/fbink.c
@@ -4350,12 +4350,10 @@ int
 					for (unsigned int k = 0U; k < lw; k++) {
 						if (lnPtr[k] == 0U) {
 							// No coverage (transparent) -> background
-							pixel = bgP;
-							put_pixel(paint_point, &pixel, true);
+							put_pixel(paint_point, &bgP, true);
 						} else if (lnPtr[k] == 0xFF) {
 							// Full coverage (opaque) -> foreground
-							pixel = fgP;
-							put_pixel(paint_point, &pixel, true);
+							put_pixel(paint_point, &fgP, true);
 						} else {
 							// AA, blend it using the coverage mask as alpha
 							pixel.bgra.color.r = pixel.bgra.color.g = pixel.bgra.color.b =
@@ -4379,8 +4377,7 @@ int
 					for (unsigned int k = 0U; k < lw; k++) {
 						if (lnPtr[k] == 0U) {
 							// No coverage (transparent) -> background
-							pixel = bgP;
-							put_pixel(paint_point, &pixel, true);
+							put_pixel(paint_point, &bgP, true);
 						} else if (lnPtr[k] != 0xFF) {
 							// AA, blend it using the coverage mask as alpha,
 							// and the underlying pixel as fg

--- a/fbink.c
+++ b/fbink.c
@@ -2410,31 +2410,31 @@ static int
 	switch (vInfo.bits_per_pixel) {
 		case 4U:
 			//fxpPutPixel      = &put_pixel_Gray4;
-			//fxpGetPixel      = &get_pixel_Gray4;
+			fxpGetPixel      = &get_pixel_Gray4;
 			penFGPixel.gray8 = penFGColor;
 			penBGPixel.gray8 = penBGColor;
 			break;
 		case 8U:
 			//fxpPutPixel      = &put_pixel_Gray8;
-			//fxpGetPixel      = &get_pixel_Gray8;
+			fxpGetPixel      = &get_pixel_Gray8;
 			penFGPixel.gray8 = penFGColor;
 			penBGPixel.gray8 = penBGColor;
 			break;
 		case 16U:
 			//fxpPutPixel       = &put_pixel_RGB565;
-			//fxpGetPixel       = &get_pixel_RGB565;
+			fxpGetPixel       = &get_pixel_RGB565;
 			penFGPixel.rgb565 = pack_rgb565(penFGColor, penFGColor, penFGColor);
 			penBGPixel.rgb565 = pack_rgb565(penBGColor, penBGColor, penBGColor);
 			break;
 		case 24U:
 			//fxpPutPixel             = &put_pixel_RGB24;
-			//fxpGetPixel             = &get_pixel_RGB24;
+			fxpGetPixel             = &get_pixel_RGB24;
 			penFGPixel.bgra.color.r = penFGPixel.bgra.color.g = penFGPixel.bgra.color.b = penFGColor;
 			penBGPixel.bgra.color.r = penBGPixel.bgra.color.g = penBGPixel.bgra.color.b = penBGColor;
 			break;
 		case 32U:
 			//fxpPutPixel             = &put_pixel_RGB32;
-			//fxpGetPixel             = &get_pixel_RGB32;
+			fxpGetPixel             = &get_pixel_RGB32;
 			penFGPixel.bgra.color.a = 0xFF;
 			penFGPixel.bgra.color.r = penFGPixel.bgra.color.g = penFGPixel.bgra.color.b = penFGColor;
 			penBGPixel.bgra.color.a                                                     = 0xFF;

--- a/fbink.c
+++ b/fbink.c
@@ -496,6 +496,7 @@ static void
     get_pixel(FBInkCoordinates coords, FBInkPixel* restrict px)
 {
 	// Handle rotation now, so we can properly validate if the pixel is off-screen or not ;).
+	// fbink_init() takes care of setting this global pointer to the right function...
 	(*fxpRotateCoords)(&coords);
 
 	// NOTE: Discard off-screen pixels!
@@ -515,9 +516,18 @@ static void
 		return;
 	}
 
-	// fbink_init() takes care of setting this global pointer to the right function for the fb's bpp
-	// TODO: If ladder here, too?
-	(*fxpGetPixel)(&coords, px);
+	// NOTE: Hmm, here, an if ladder appears to be ever so *slightly* faster than going through the function pointer...
+	if (vInfo.bits_per_pixel == 4U) {
+		get_pixel_Gray4(&coords, px);
+	} else if (vInfo.bits_per_pixel == 8U) {
+		get_pixel_Gray8(&coords, px);
+	} else if (vInfo.bits_per_pixel == 16U) {
+		get_pixel_RGB565(&coords, px);
+	} else if (vInfo.bits_per_pixel == 24U) {
+		get_pixel_RGB24(&coords, px);
+	} else if (vInfo.bits_per_pixel == 32U) {
+		get_pixel_RGB32(&coords, px);
+	}
 }
 
 // Helper function to draw a rectangle in given color

--- a/fbink.c
+++ b/fbink.c
@@ -419,7 +419,7 @@ static void
 		uint8_t b          = *((unsigned char*) (fbPtr + pix_offset));
 
 		// Even pixel: high nibble
-		uint8_t v = (b & 0xF0);
+		uint8_t v    = (b & 0xF0);
 		px->gray4.hi = (v | (v >> 4U));
 		// pull the top/left nibble, expanded to 8bit
 		// or: (uint8_t)((((b) >> 4) & 0x0F) * 0x11);
@@ -772,8 +772,8 @@ static struct mxcfb_rect
 		if (vInfo.bits_per_pixel == 16U) {
 			const uint8_t fgcolor = penFGColor ^ 0xFF;
 			const uint8_t bgcolor = penBGColor ^ 0xFF;
-			fgP.rgb565 = pack_rgb565(fgcolor, fgcolor, fgcolor);
-			bgP.rgb565 = pack_rgb565(bgcolor, bgcolor, bgcolor);
+			fgP.rgb565            = pack_rgb565(fgcolor, fgcolor, fgcolor);
+			bgP.rgb565            = pack_rgb565(bgcolor, bgcolor, bgcolor);
 		} else {
 			fgP.bgra.p ^= 0x00FFFFFF;
 			bgP.bgra.p ^= 0x00FFFFFF;
@@ -1017,9 +1017,9 @@ static struct mxcfb_rect
 			// Get the glyph's pixmap (width <= 8 -> uint8_t)
 			const unsigned char* restrict bitmap = NULL;
 #ifdef FBINK_WITH_FONTS
-			bitmap                               = (*fxpFont8xGetBitmap)(ch);
+			bitmap = (*fxpFont8xGetBitmap)(ch);
 #else
-			bitmap                               = font8x8_get_bitmap(ch);
+		bitmap = font8x8_get_bitmap(ch);
 #endif
 
 			// Crappy macro to avoid repeating myself in each branch...
@@ -1081,22 +1081,22 @@ static struct mxcfb_rect
 						if (is_fgpx && !fbink_cfg->is_fgless) {                                  \
 							if (fbink_cfg->is_overlay) {                                     \
 								get_pixel(coords, &fbP);                                 \
-								fbP.gray8 ^= 0xFF;                                           \
+								fbP.gray8 ^= 0xFF;                                       \
 								/* NOTE: Don't touch g & r if it's not needed! */        \
 								/*       It's especially important on 4bpp, */           \
 								/*       to avoid clobbering the low nibble, */          \
 								/*       which we store in g... */                       \
 								if (vInfo.bits_per_pixel > 8U) {                         \
-									fbP.bgra.color.g ^= 0xFF;                                   \
-									fbP.bgra.color.r ^= 0xFF;                                   \
+									fbP.bgra.color.g ^= 0xFF;                        \
+									fbP.bgra.color.r ^= 0xFF;                        \
 								}                                                        \
 								pxP = &fbP;                                              \
-								put_pixel(coords, pxP, false);                                          \
-							} else {                                                               \
-								put_pixel(coords, pxP, true);                                          \
-							} \
+								put_pixel(coords, pxP, false);                           \
+							} else {                                                         \
+								put_pixel(coords, pxP, true);                            \
+							}                                                                \
 						} else if (!is_fgpx && fbink_cfg->is_fgless) {                           \
-							put_pixel(coords, pxP, true);                                          \
+							put_pixel(coords, pxP, true);                                    \
 						}                                                                        \
 					}                                                                                \
 				}                                                                                        \
@@ -2407,35 +2407,35 @@ static int
 	// Use the appropriate get/put pixel functions, and pack the pen colors into the appropriate pixel format...
 	switch (vInfo.bits_per_pixel) {
 		case 4U:
-			fxpPutPixel = &put_pixel_Gray4;
-			fxpGetPixel = &get_pixel_Gray4;
+			fxpPutPixel      = &put_pixel_Gray4;
+			fxpGetPixel      = &get_pixel_Gray4;
 			penFGPixel.gray8 = penFGColor;
 			penBGPixel.gray8 = penBGColor;
 			break;
 		case 8U:
-			fxpPutPixel = &put_pixel_Gray8;
-			fxpGetPixel = &get_pixel_Gray8;
+			fxpPutPixel      = &put_pixel_Gray8;
+			fxpGetPixel      = &get_pixel_Gray8;
 			penFGPixel.gray8 = penFGColor;
 			penBGPixel.gray8 = penBGColor;
 			break;
 		case 16U:
-			fxpPutPixel = &put_pixel_RGB565;
-			fxpGetPixel = &get_pixel_RGB565;
+			fxpPutPixel       = &put_pixel_RGB565;
+			fxpGetPixel       = &get_pixel_RGB565;
 			penFGPixel.rgb565 = pack_rgb565(penFGColor, penFGColor, penFGColor);
 			penBGPixel.rgb565 = pack_rgb565(penBGColor, penBGColor, penBGColor);
 			break;
 		case 24U:
-			fxpPutPixel = &put_pixel_RGB24;
-			fxpGetPixel = &get_pixel_RGB24;
+			fxpPutPixel             = &put_pixel_RGB24;
+			fxpGetPixel             = &get_pixel_RGB24;
 			penFGPixel.bgra.color.r = penFGPixel.bgra.color.g = penFGPixel.bgra.color.b = penFGColor;
 			penBGPixel.bgra.color.r = penBGPixel.bgra.color.g = penBGPixel.bgra.color.b = penBGColor;
 			break;
 		case 32U:
-			fxpPutPixel = &put_pixel_RGB32;
-			fxpGetPixel = &get_pixel_RGB32;
+			fxpPutPixel             = &put_pixel_RGB32;
+			fxpGetPixel             = &get_pixel_RGB32;
 			penFGPixel.bgra.color.a = 0xFF;
 			penFGPixel.bgra.color.r = penFGPixel.bgra.color.g = penFGPixel.bgra.color.b = penFGColor;
-			penBGPixel.bgra.color.a = 0xFF;
+			penBGPixel.bgra.color.a                                                     = 0xFF;
 			penBGPixel.bgra.color.r = penBGPixel.bgra.color.g = penBGPixel.bgra.color.b = penBGColor;
 			break;
 		default:
@@ -4079,8 +4079,8 @@ int
 	const uint8_t   fgcolor    = penFGColor ^ invert;
 	const uint8_t   bgcolor    = penBGColor ^ invert;
 	const short int layer_diff = (short int) (fgcolor - bgcolor);
-	FBInkPixel fgP = penFGPixel;
-	FBInkPixel bgP = penBGPixel;
+	FBInkPixel      fgP        = penFGPixel;
+	FBInkPixel      bgP        = penBGPixel;
 	if (is_inverted) {
 		// NOTE: And, of course, RGB565 is terrible. Inverting the lossy packed value would be even lossier...
 		if (vInfo.bits_per_pixel == 16U) {
@@ -4315,8 +4315,8 @@ int
 
 		FBInkPixel pixel;
 		pixel.bgra.color.a = 0xFF;
-		start_x          = paint_point.x;
-		lnPtr            = line_buff;
+		start_x            = paint_point.x;
+		lnPtr              = line_buff;
 		// Normal painting to framebuffer. Please forgive the code repetition. Performance...
 		// What we get from stbtt is an alpha coverage mask, hence the need for alpha-blending for anti-aliasing.
 		// As it's obviously expensive, we try to avoid it if possible (on fully opaque & fully transparent pixels).
@@ -4335,7 +4335,8 @@ int
 				}
 				for (int j = 0; j < max_line_height; j++) {
 					for (unsigned int k = 0U; k < lw; k++) {
-						pixel.bgra.color.r = pixel.bgra.color.g = pixel.bgra.color.b = lnPtr[k] ^ ainv;
+						pixel.bgra.color.r = pixel.bgra.color.g = pixel.bgra.color.b =
+						    lnPtr[k] ^ ainv;
 						put_pixel(paint_point, &pixel, false);
 						paint_point.x++;
 					}
@@ -4369,8 +4370,8 @@ int
 				}
 			}
 		} else if (is_fgless) {
-			FBInkPixel fb_px = { 0U };
-			uint16_t   pmul_bg  = (uint16_t)(bgcolor * 0xFF);
+			FBInkPixel fb_px   = { 0U };
+			uint16_t   pmul_bg = (uint16_t)(bgcolor * 0xFF);
 			// NOTE: One more branch needed because 4bpp fbs are terrible...
 			if (vInfo.bits_per_pixel > 4U) {
 				// 8, 16, 24 & 32bpp
@@ -4431,11 +4432,14 @@ int
 							// and the underlying pixel as bg
 							get_pixel(paint_point, &fb_px);
 							pixel.bgra.color.r = (uint8_t) DIV255(
-							    (MUL255(fb_px.bgra.color.r) + ((fgcolor - fb_px.bgra.color.r) * lnPtr[k])));
+							    (MUL255(fb_px.bgra.color.r) +
+							     ((fgcolor - fb_px.bgra.color.r) * lnPtr[k])));
 							pixel.bgra.color.g = (uint8_t) DIV255(
-							    (MUL255(fb_px.bgra.color.g) + ((fgcolor - fb_px.bgra.color.g) * lnPtr[k])));
+							    (MUL255(fb_px.bgra.color.g) +
+							     ((fgcolor - fb_px.bgra.color.g) * lnPtr[k])));
 							pixel.bgra.color.b = (uint8_t) DIV255(
-							    (MUL255(fb_px.bgra.color.b) + ((fgcolor - fb_px.bgra.color.b) * lnPtr[k])));
+							    (MUL255(fb_px.bgra.color.b) +
+							     ((fgcolor - fb_px.bgra.color.b) * lnPtr[k])));
 							put_pixel(paint_point, &pixel, false);
 						}
 						paint_point.x++;
@@ -4481,13 +4485,16 @@ int
 							get_pixel(paint_point, &fb_px);
 							pixel.bgra.color.r = (uint8_t) DIV255(
 							    (MUL255(fb_px.bgra.color.r) +
-							     (((fb_px.bgra.color.r ^ 0xFF) - fb_px.bgra.color.r) * lnPtr[k])));
+							     (((fb_px.bgra.color.r ^ 0xFF) - fb_px.bgra.color.r) *
+							      lnPtr[k])));
 							pixel.bgra.color.g = (uint8_t) DIV255(
 							    (MUL255(fb_px.bgra.color.g) +
-							     (((fb_px.bgra.color.g ^ 0xFF) - fb_px.bgra.color.g) * lnPtr[k])));
+							     (((fb_px.bgra.color.g ^ 0xFF) - fb_px.bgra.color.g) *
+							      lnPtr[k])));
 							pixel.bgra.color.b = (uint8_t) DIV255(
 							    (MUL255(fb_px.bgra.color.b) +
-							     (((fb_px.bgra.color.b ^ 0xFF) - fb_px.bgra.color.b) * lnPtr[k])));
+							     (((fb_px.bgra.color.b ^ 0xFF) - fb_px.bgra.color.b) *
+							      lnPtr[k])));
 							put_pixel(paint_point, &pixel, false);
 						}
 						paint_point.x++;
@@ -4503,9 +4510,9 @@ int
 						// AA, blend it using the coverage mask as alpha, and the underlying pixel as bg
 						// Without forgetting our foreground color trickery...
 						get_pixel(paint_point, &fb_px);
-						pixel.gray4.hi =
-						    (uint8_t) DIV255((MUL255(fb_px.gray4.hi) +
-								      (((fb_px.gray4.hi ^ 0xFF) - fb_px.gray4.hi) * lnPtr[k])));
+						pixel.gray4.hi = (uint8_t) DIV255(
+						    (MUL255(fb_px.gray4.hi) +
+						     (((fb_px.gray4.hi ^ 0xFF) - fb_px.gray4.hi) * lnPtr[k])));
 						// Don't touch the low nibble...
 						pixel.gray4.lo = fb_px.gray4.lo;
 						put_pixel(paint_point, &pixel, true);
@@ -5070,18 +5077,18 @@ int
 	switch (vInfo.bits_per_pixel) {
 		case 4U:
 		case 8U:
-			emptyP.gray8 = emptyC;
+			emptyP.gray8  = emptyC;
 			borderP.gray8 = borderC;
 			break;
 		case 16U:
-			emptyP.rgb565 = pack_rgb565(emptyC, emptyC, emptyC);
+			emptyP.rgb565  = pack_rgb565(emptyC, emptyC, emptyC);
 			borderP.rgb565 = pack_rgb565(borderC, borderC, borderC);
 			break;
 		case 24U:
 		case 32U:
 			emptyP.bgra.color.a = 0xFF;
 			emptyP.bgra.color.r = emptyP.bgra.color.g = emptyP.bgra.color.b = emptyC;
-			borderP.bgra.color.a = 0xFF;
+			borderP.bgra.color.a                                            = 0xFF;
 			borderP.bgra.color.r = borderP.bgra.color.g = borderP.bgra.color.b = borderC;
 			break;
 	}
@@ -6206,7 +6213,8 @@ static int
 							pixel.bgra.color.b = img_px.color.b;
 						}
 						// Pack it
-						pixel.rgb565 = pack_rgb565(pixel.bgra.color.r, pixel.bgra.color.g, pixel.bgra.color.b);
+						pixel.rgb565 = pack_rgb565(
+						    pixel.bgra.color.r, pixel.bgra.color.g, pixel.bgra.color.b);
 
 						coords.x = (unsigned short int) (i + x_off);
 						coords.y = (unsigned short int) (j + y_off);
@@ -6240,7 +6248,8 @@ static int
 							pixel.bgra.color.b = dither_o8x8(i, j, pixel.bgra.color.b);
 						}
 						// Pack it
-						pixel.rgb565 = pack_rgb565(pixel.bgra.color.r, pixel.bgra.color.g, pixel.bgra.color.b);
+						pixel.rgb565 = pack_rgb565(
+						    pixel.bgra.color.r, pixel.bgra.color.g, pixel.bgra.color.b);
 
 						put_pixel_RGB565(&coords, &pixel);
 					}
@@ -6264,7 +6273,8 @@ static int
 						pixel.bgra.color.b = data[pix_offset + 2U] ^ invert;
 					}
 					// Pack it
-					pixel.rgb565 = pack_rgb565(pixel.bgra.color.r, pixel.bgra.color.g, pixel.bgra.color.b);
+					pixel.rgb565 =
+					    pack_rgb565(pixel.bgra.color.r, pixel.bgra.color.g, pixel.bgra.color.b);
 
 					FBInkCoordinates coords;
 					coords.x = (unsigned short int) (i + x_off);

--- a/fbink.c
+++ b/fbink.c
@@ -336,9 +336,10 @@ static void
 // Handle a few sanity checks...
 // NOTE: If you can, prefer using the right put_pixel_* function directly.
 //       While the bounds checking is generally rather cheap,
+//       (i.e., (*fxpPutPixel) is only marginally faster than put_pixel()),
 //       the overhead of going through the function pointers is rather large
-//       (i.e., put_pixel() can be twice as slow as put_pixel_Gray8()).
-//       It's still faster than branching or switching, though ;).
+//       (i.e., put_pixel() can be twice as slow as put_pixel_*()).
+//       On our target HW, it's still faster than branching or switching, though ;).
 static void
     put_pixel(FBInkCoordinates coords, const FBInkPixel* restrict px)
 {

--- a/fbink.c
+++ b/fbink.c
@@ -2409,32 +2409,32 @@ static int
 	// Use the appropriate get/put pixel functions, and pack the pen colors into the appropriate pixel format...
 	switch (vInfo.bits_per_pixel) {
 		case 4U:
-			fxpPutPixel      = &put_pixel_Gray4;
-			fxpGetPixel      = &get_pixel_Gray4;
+			//fxpPutPixel      = &put_pixel_Gray4;
+			//fxpGetPixel      = &get_pixel_Gray4;
 			penFGPixel.gray8 = penFGColor;
 			penBGPixel.gray8 = penBGColor;
 			break;
 		case 8U:
-			fxpPutPixel      = &put_pixel_Gray8;
-			fxpGetPixel      = &get_pixel_Gray8;
+			//fxpPutPixel      = &put_pixel_Gray8;
+			//fxpGetPixel      = &get_pixel_Gray8;
 			penFGPixel.gray8 = penFGColor;
 			penBGPixel.gray8 = penBGColor;
 			break;
 		case 16U:
-			fxpPutPixel       = &put_pixel_RGB565;
-			fxpGetPixel       = &get_pixel_RGB565;
+			//fxpPutPixel       = &put_pixel_RGB565;
+			//fxpGetPixel       = &get_pixel_RGB565;
 			penFGPixel.rgb565 = pack_rgb565(penFGColor, penFGColor, penFGColor);
 			penBGPixel.rgb565 = pack_rgb565(penBGColor, penBGColor, penBGColor);
 			break;
 		case 24U:
-			fxpPutPixel             = &put_pixel_RGB24;
-			fxpGetPixel             = &get_pixel_RGB24;
+			//fxpPutPixel             = &put_pixel_RGB24;
+			//fxpGetPixel             = &get_pixel_RGB24;
 			penFGPixel.bgra.color.r = penFGPixel.bgra.color.g = penFGPixel.bgra.color.b = penFGColor;
 			penBGPixel.bgra.color.r = penBGPixel.bgra.color.g = penBGPixel.bgra.color.b = penBGColor;
 			break;
 		case 32U:
-			fxpPutPixel             = &put_pixel_RGB32;
-			fxpGetPixel             = &get_pixel_RGB32;
+			//fxpPutPixel             = &put_pixel_RGB32;
+			//fxpGetPixel             = &get_pixel_RGB32;
 			penFGPixel.bgra.color.a = 0xFF;
 			penFGPixel.bgra.color.r = penFGPixel.bgra.color.g = penFGPixel.bgra.color.b = penFGColor;
 			penBGPixel.bgra.color.a                                                     = 0xFF;

--- a/fbink.c
+++ b/fbink.c
@@ -561,16 +561,22 @@ static void
 	// Do signed maths, to account for the fact that x or y might already be OOB!
 	if (x + w > screenWidth) {
 		w = (unsigned short int) MAX(0, (w - ((x + w) - (int) screenWidth)));
+#ifdef DEBUG
 		LOG("Chopped rectangle width to %hu", w);
+#endif
 	}
 	if (y + h > screenHeight) {
 		h = (unsigned short int) MAX(0, (h - ((y + h) - (int) screenHeight)));
+#ifdef DEBUG
 		LOG("Chopped rectangle height to %hu", h);
+#endif
 	}
 
 	// Abort early if that left us with an empty rectangle ;).
 	if (w == 0U || h == 0U) {
+#ifdef DEBUG
 		LOG("Skipped empty %hux%hu rectangle @ (%hu, %hu)", w, h, x, y);
+#endif
 		return;
 	}
 
@@ -612,7 +618,9 @@ static void
 			memset(p, px->gray8, bpp * region.width);
 		}
 	}
+#ifdef DEBUG
 	LOG("Filled a %hux%hu rectangle @ (%hu, %hu)", w, h, x, y);
+#endif
 }
 
 // Helper function to clear the screen - fill whole screen with given color

--- a/fbink.c
+++ b/fbink.c
@@ -947,7 +947,7 @@ static struct mxcfb_rect
 	size_t           ci     = 0U;
 	uint32_t         ch     = 0U;
 	FBInkCoordinates coords = { 0U };
-	FBInkPixel*      pxC;
+	FBInkPixel*      pxP;
 	// NOTE: We don't do much sanity checking on hoffset/voffset,
 	//       because we want to allow pushing part of the string off-screen
 	//       (we basically only make sure it won't screw up the region rectangle too badly).
@@ -1004,16 +1004,16 @@ static struct mxcfb_rect
 				/* Each element encodes a full row, we access a column's bit in that row by shifting. */ \
 				if (bitmap[y] & 1U << x) {                                                               \
 					/* bit was set, pixel is fg! */                                                  \
-					pxC = &fgP;                                                                      \
+					pxP = &fgP;                                                                      \
 				} else {                                                                                 \
 					/* bit was unset, pixel is bg */                                                 \
-					pxC = &bgP;                                                                      \
+					pxP = &bgP;                                                                      \
 				}                                                                                        \
 				/* Initial coordinates, before we generate the extra pixels from the scaling factor */   \
 				cx = (unsigned short int) (x_offs + i);                                                  \
 				cy = (unsigned short int) (y_offs + j);                                                  \
 				/* We already know the final pixel value, so we can take a shortcut w/ fill_rect :) */   \
-				fill_rect(cx, cy, FONTSIZE_MULT, FONTSIZE_MULT, pxC);                                    \
+				fill_rect(cx, cy, FONTSIZE_MULT, FONTSIZE_MULT, pxP);                                    \
 			}                                                                                                \
 		}                                                                                                        \
 	} else {                                                                                                         \
@@ -1028,11 +1028,11 @@ static struct mxcfb_rect
 				/* Each element encodes a full row, we access a column's bit in that row by shifting. */ \
 				if (bitmap[y] & 1U << x) {                                                               \
 					/* bit was set, pixel is fg! */                                                  \
-					pxC     = &fgP;                                                                  \
+					pxP     = &fgP;                                                                  \
 					is_fgpx = true;                                                                  \
 				} else {                                                                                 \
 					/* bit was unset, pixel is bg */                                                 \
-					pxC     = &bgP;                                                                  \
+					pxP     = &bgP;                                                                  \
 					is_fgpx = false;                                                                 \
 				}                                                                                        \
 				/* Initial coordinates, before we generate the extra pixels from the scaling factor */   \
@@ -1058,11 +1058,11 @@ static struct mxcfb_rect
 									fbP.bgra.color.g ^= 0xFF;                                   \
 									fbP.bgra.color.r ^= 0xFF;                                   \
 								}                                                        \
-								pxC = &fbP;                                              \
+								pxP = &fbP;                                              \
 							}                                                                \
-							put_pixel(coords, pxC);                                          \
+							put_pixel(coords, pxP);                                          \
 						} else if (!is_fgpx && fbink_cfg->is_fgless) {                           \
-							put_pixel(coords, pxC);                                          \
+							put_pixel(coords, pxP);                                          \
 						}                                                                        \
 					}                                                                                \
 				}                                                                                        \

--- a/fbink_button_scan.c
+++ b/fbink_button_scan.c
@@ -133,13 +133,13 @@ static bool
 		// NOTE: get_pixel_* will only set gray8 @ 4 & 8bpp! (It will unpack RGB565 to RGB32, though ;)).
 		if (vInfo.bits_per_pixel > 8U) {
 			LOG("On iteration nr. %hhu of %hu, pixel (%hu, %hu) was #%02hhX%02hhX%02hhX",
-			i,
-			iterations,
-			coords.x,
-			coords.y,
-			pixel.bgra.color.r,
-			pixel.bgra.color.g,
-			pixel.bgra.color.b);
+			    i,
+			    iterations,
+			    coords.x,
+			    coords.y,
+			    pixel.bgra.color.r,
+			    pixel.bgra.color.g,
+			    pixel.bgra.color.b);
 
 			// Got it!
 			if (pixel.bgra.color.r == v && pixel.bgra.color.g == v && pixel.bgra.color.b == v) {
@@ -147,11 +147,11 @@ static bool
 			}
 		} else {
 			LOG("On iteration nr. %hhu of %hu, pixel (%hu, %hu) was #%02hhX",
-			i,
-			iterations,
-			coords.x,
-			coords.y,
-			pixel.gray8);
+			    i,
+			    iterations,
+			    coords.x,
+			    coords.y,
+			    pixel.gray8);
 
 			// Got it!
 			if (pixel.gray8 == v) {
@@ -405,7 +405,9 @@ int
 			(*fxpGetPixel)(&coords, &pixel);
 
 			// NOTE: Again, get_pixel_* will only set gray8 @ 4 & 8bpp
-			if ((vInfo.bits_per_pixel > 8U && pixel.bgra.color.r == button_color.r && pixel.bgra.color.g == button_color.g && pixel.bgra.color.b == button_color.b) || (vInfo.bits_per_pixel <= 8U && pixel.gray8 == button_color.b)) {
+			if ((vInfo.bits_per_pixel > 8U && pixel.bgra.color.r == button_color.r &&
+			     pixel.bgra.color.g == button_color.g && pixel.bgra.color.b == button_color.b) ||
+			    (vInfo.bits_per_pixel <= 8U && pixel.gray8 == button_color.b)) {
 				// Found a pixel of the right color for a button...
 				button_width++;
 			} else {
@@ -454,7 +456,9 @@ int
 			(*fxpGetPixel)(&coords, &pixel);
 
 			// NOTE: Again, with the gray/rgb dance...
-			if ((vInfo.bits_per_pixel > 8U && pixel.bgra.color.r == button_color.r && pixel.bgra.color.g == button_color.g && pixel.bgra.color.b == button_color.b) || (vInfo.bits_per_pixel <= 8U && pixel.gray8 == button_color.b)) {
+			if ((vInfo.bits_per_pixel > 8U && pixel.bgra.color.r == button_color.r &&
+			     pixel.bgra.color.g == button_color.g && pixel.bgra.color.b == button_color.b) ||
+			    (vInfo.bits_per_pixel <= 8U && pixel.gray8 == button_color.b)) {
 				// Found a pixel of the right color for a button...
 				button_height++;
 			} else {

--- a/fbink_button_scan.c
+++ b/fbink_button_scan.c
@@ -130,7 +130,8 @@ static bool
 		nanosleep(&zzz, NULL);
 
 		(*fxpGetPixel)(&coords, &pixel);
-		// NOTE: get_pixel_* will only set gray8 @ 4 & 8bpp! (It will unpack RGB565 to RGB32, though ;)).
+		// NOTE: get_pixel_* will only set gray8 (leaving at least bgra.color.r untouched) @ 4 & 8bpp!
+		//       (It will unpack RGB565 to RGB32, though ;)).
 		if (vInfo.bits_per_pixel > 8U) {
 			LOG("On iteration nr. %hhu of %hu, pixel (%hu, %hu) was #%02hhX%02hhX%02hhX",
 			    i,

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -99,6 +99,7 @@ static void
 #ifdef FBINK_WITH_FONTS
 	    "\t\t\t\tAvailable font families: IBM, UNSCII, ALT, THIN, FANTASY, MCR, TALL, BLOCK,\n"
 	    "\t\t\t\t\t\tLEGGIE, VEGGIE, KATES, FKP, CTRLD, ORP, ORPB, ORPI, SCIENTIFICA, SCIENTIFICAB, SCIENTIFICAI, TERMINUS, TERMINUSB, FATTY, SPLEEN, TEWI, TEWIB, TOPAZ, MICROKNIGHT, VGA\n"
+	    "\t\t\t\tNOTE: On low dpi, 600x800 devices, ORP or TEWI's form factor may feel more familiar at default scaling.\n"
 #else
 	    "\t\t\t\tAvailable font families: IBM\n"
 #endif

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -335,6 +335,8 @@ unsigned short int       FONTH          = 8U;
 uint8_t                  FONTSIZE_MULT  = 1U;
 uint8_t                  penFGColor     = 0x00;
 uint8_t                  penBGColor     = 0xFF;
+FBInkPixel               penFGPixel;
+FBInkPixel               penBGPixel;
 // Slightly arbitrary-ish fallback values
 unsigned short int MAXROWS = 45U;
 unsigned short int MAXCOLS = 32U;
@@ -378,6 +380,8 @@ static void rotate_touch_coordinates(FBInkCoordinates* restrict);
 #	endif
 #endif
 static void rotate_coordinates_nop(FBInkCoordinates* restrict __attribute__((unused)));
+
+static uint16_t pack_rgb565(uint8_t, uint8_t, uint8_t);
 
 static void put_pixel_Gray4(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
 static void put_pixel_Gray8(const FBInkCoordinates* restrict, const FBInkPixel* restrict);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -347,8 +347,8 @@ bool g_isQuiet = false;
 // This should be a pretty accurate fallback...
 long int USER_HZ = 100;
 // Pointers to the appropriate put_pixel/get_pixel functions for the fb's bpp
-void (*fxpPutPixel)(const FBInkCoordinates* restrict, const FBInkPixel* restrict) = NULL;
-void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkPixel* restrict)       = NULL;
+//void (*fxpPutPixel)(const FBInkCoordinates* restrict, const FBInkPixel* restrict) = NULL;
+//void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkPixel* restrict)       = NULL;
 // As well as the appropriate coordinates rotation functions...
 void (*fxpRotateCoords)(FBInkCoordinates* restrict)  = NULL;
 void (*fxpRotateRegion)(struct mxcfb_rect* restrict) = NULL;

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -381,7 +381,7 @@ static void rotate_touch_coordinates(FBInkCoordinates* restrict);
 #endif
 static void rotate_coordinates_nop(FBInkCoordinates* restrict __attribute__((unused)));
 
-static uint16_t pack_rgb565(uint8_t, uint8_t, uint8_t);
+static inline uint16_t pack_rgb565(uint8_t, uint8_t, uint8_t);
 
 static void put_pixel_Gray4(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
 static void put_pixel_Gray8(const FBInkCoordinates* restrict, const FBInkPixel* restrict);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -345,7 +345,7 @@ bool g_isQuiet = false;
 // This should be a pretty accurate fallback...
 long int USER_HZ = 100;
 // Pointers to the appropriate put_pixel/get_pixel functions for the fb's bpp
-void (*fxpPutPixel)(const FBInkCoordinates* restrict, const FBInkColor* restrict) = NULL;
+void (*fxpPutPixel)(const FBInkCoordinates* restrict, const FBInkPixel* restrict) = NULL;
 void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkColor* restrict)       = NULL;
 // As well as the appropriate coordinates rotation functions...
 void (*fxpRotateCoords)(FBInkCoordinates* restrict)  = NULL;
@@ -379,14 +379,14 @@ static void rotate_touch_coordinates(FBInkCoordinates* restrict);
 #endif
 static void rotate_coordinates_nop(FBInkCoordinates* restrict __attribute__((unused)));
 
-static void put_pixel_Gray4(const FBInkCoordinates* restrict, const FBInkColor* restrict);
-static void put_pixel_Gray8(const FBInkCoordinates* restrict, const FBInkColor* restrict);
-static void put_pixel_RGB24(const FBInkCoordinates* restrict, const FBInkColor* restrict);
-static void put_pixel_RGB32(const FBInkCoordinates* restrict, const FBInkColor* restrict);
-static void put_pixel_RGB565(const FBInkCoordinates* restrict, const FBInkColor* restrict);
+static void put_pixel_Gray4(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
+static void put_pixel_Gray8(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
+static void put_pixel_RGB24(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
+static void put_pixel_RGB32(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
+static void put_pixel_RGB565(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
 // NOTE: We pass coordinates by value here, because a rotation transformation *may* be applied to them,
 //       and that's a rotation that the caller will *never* care about.
-static void put_pixel(FBInkCoordinates, const FBInkColor* restrict);
+static void put_pixel(FBInkCoordinates, const FBInkPixel* restrict);
 // NOTE: On the other hand, if you happen to be calling function pointers directly,
 //       it's left to you to not do anything stupid ;)
 
@@ -424,7 +424,7 @@ static void fill_rect(unsigned short int,
 		      unsigned short int,
 		      unsigned short int,
 		      unsigned short int,
-		      const FBInkColor* restrict);
+		      const FBInkPixel* restrict);
 static void clear_screen(int UNUSED_BY_NOTKINDLE, uint8_t, bool UNUSED_BY_NOTKINDLE);
 
 static const unsigned char* font8x8_get_bitmap(uint32_t);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -348,7 +348,7 @@ bool g_isQuiet = false;
 long int USER_HZ = 100;
 // Pointers to the appropriate put_pixel/get_pixel functions for the fb's bpp
 //void (*fxpPutPixel)(const FBInkCoordinates* restrict, const FBInkPixel* restrict) = NULL;
-//void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkPixel* restrict)       = NULL;
+void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkPixel* restrict) = NULL;
 // As well as the appropriate coordinates rotation functions...
 void (*fxpRotateCoords)(FBInkCoordinates* restrict)  = NULL;
 void (*fxpRotateRegion)(struct mxcfb_rect* restrict) = NULL;

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -348,7 +348,7 @@ bool g_isQuiet = false;
 long int USER_HZ = 100;
 // Pointers to the appropriate put_pixel/get_pixel functions for the fb's bpp
 void (*fxpPutPixel)(const FBInkCoordinates* restrict, const FBInkPixel* restrict) = NULL;
-void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkColor* restrict)       = NULL;
+void (*fxpGetPixel)(const FBInkCoordinates* restrict, FBInkPixel* restrict)       = NULL;
 // As well as the appropriate coordinates rotation functions...
 void (*fxpRotateCoords)(FBInkCoordinates* restrict)  = NULL;
 void (*fxpRotateRegion)(struct mxcfb_rect* restrict) = NULL;
@@ -394,13 +394,13 @@ static void put_pixel(FBInkCoordinates, const FBInkPixel* restrict);
 // NOTE: On the other hand, if you happen to be calling function pointers directly,
 //       it's left to you to not do anything stupid ;)
 
-static void get_pixel_Gray4(const FBInkCoordinates* restrict, FBInkColor* restrict);
-static void get_pixel_Gray8(const FBInkCoordinates* restrict, FBInkColor* restrict);
-static void get_pixel_RGB24(const FBInkCoordinates* restrict, FBInkColor* restrict);
-static void get_pixel_RGB32(const FBInkCoordinates* restrict, FBInkColor* restrict);
-static void get_pixel_RGB565(const FBInkCoordinates* restrict, FBInkColor* restrict);
+static void get_pixel_Gray4(const FBInkCoordinates* restrict, FBInkPixel* restrict);
+static void get_pixel_Gray8(const FBInkCoordinates* restrict, FBInkPixel* restrict);
+static void get_pixel_RGB24(const FBInkCoordinates* restrict, FBInkPixel* restrict);
+static void get_pixel_RGB32(const FBInkCoordinates* restrict, FBInkPixel* restrict);
+static void get_pixel_RGB565(const FBInkCoordinates* restrict, FBInkPixel* restrict);
 // NOTE: Same as put_pixel ;)
-static void get_pixel(FBInkCoordinates, FBInkColor* restrict);
+static void get_pixel(FBInkCoordinates, FBInkPixel* restrict);
 
 #if defined(FBINK_WITH_IMAGE) || defined(FBINK_WITH_OPENTYPE)
 // This is only needed for alpha blending in the image or OpenType codepath ;).

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -390,7 +390,7 @@ static void put_pixel_RGB32(const FBInkCoordinates* restrict, const FBInkPixel* 
 static void put_pixel_RGB565(const FBInkCoordinates* restrict, const FBInkPixel* restrict);
 // NOTE: We pass coordinates by value here, because a rotation transformation *may* be applied to them,
 //       and that's a rotation that the caller will *never* care about.
-static void put_pixel(FBInkCoordinates, const FBInkPixel* restrict);
+static void put_pixel(FBInkCoordinates, const FBInkPixel* restrict, bool);
 // NOTE: On the other hand, if you happen to be calling function pointers directly,
 //       it's left to you to not do anything stupid ;)
 

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -143,6 +143,15 @@ typedef union
 	} color;
 } FBInkPixelBGR;
 
+// And a super type that we can use for every target bitdepth we support
+// (We need a single data type because of our function pointers shenanigans...)
+typedef union
+{
+	FBInkPixelBGRA bgra;
+	uint16_t rgb565;
+	uint8_t gray8;
+} FBInkPixel;
+
 #ifdef FBINK_WITH_OPENTYPE
 // Stores the information necessary to render a line of text
 // using OpenType/TrueType fonts

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -148,12 +148,12 @@ typedef union
 typedef union
 {
 	FBInkPixelBGRA bgra;
-	uint16_t rgb565;
-	uint8_t gray8;	// Will point to bgra.color.b
+	uint16_t       rgb565;
+	uint8_t        gray8;    // Will point to bgra.color.b
 	struct
 	{
-		uint8_t hi;	// Will point to bgra.color.b
-		uint8_t lo;	// Will point to bgra.color.g
+		uint8_t hi;    // Will point to bgra.color.b
+		uint8_t lo;    // Will point to bgra.color.g
 	} gray4;
 } FBInkPixel;
 

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -149,7 +149,12 @@ typedef union
 {
 	FBInkPixelBGRA bgra;
 	uint16_t rgb565;
-	uint8_t gray8;
+	uint8_t gray8;	// Will point to bgra.color.b
+	struct
+	{
+		uint8_t hi;	// Will point to bgra.color.b
+		uint8_t lo;	// Will point to bgra.color.g
+	} gray4;
 } FBInkPixel;
 
 #ifdef FBINK_WITH_OPENTYPE


### PR DESCRIPTION
This initially started as an experiment in replacing the `FBInkColor` struct (which was basically just a triplet of uint8_t for R, G, B) with a magical union (`FBInkPixel`) that can hold a pixel representation, properly packed for our target bitdepths (i.e., g8, rgb565, bgra). My train of thought being that, on non-trivial bitdepths (i.e., >= 16bpp), we were storing/using pen-colors as a single g8 value, and constantly repacking it once per pixel.

It turned out that the overhead of doing that wasn't as expensive as I would have thought, so, that bit of the PR actually has a minimal impact on performance ;p.
It does make most things slightly more sensible to read (except maybe button_scan), so, I'll take that ;p.

What did noticeably affect performance is switching the scaling in the fixed-cell rendering from a naive rectangle (well, square) per-pixel plotting to using fill_rect instead, because, duh. And since fill_rect is (usually) using memset, zoom!
This uncovered a sneaky issue with fill_rect @ 16bpp, because nothing except black & white actually packs into two identical bytes @ RGB565. So, fixed that by switching to a naive pixel plotting routine if needed.

What also very, very, very moderately affected performance is switching from the Get/Put Pixel function pointer to an if ladder in get/put_pixel. Probably because of the CPU's branch predictor.
That's not the first time I did this experiment, except I usually tried it with a switch: turns out that was noticeably worse, here.