### PR TITLE
PocketBook support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,7 @@ endif
 # We need libdl on PocketBook in order to dlopen InkView...
 ifdef POCKETBOOK
 	LIBS+=-ldl
+	UTILS_LIBS+=-ldl
 endif
 
 ##
@@ -547,9 +548,9 @@ else
 utils: | outdir
 	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(TOOLS_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/rota utils/rota.c
 	$(STRIP) --strip-unneeded $(OUT_DIR)/rota
-	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(TOOLS_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/fbdepth utils/fbdepth.c
+	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(TOOLS_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/fbdepth utils/fbdepth.c $(UTILS_LIBS)
 	$(STRIP) --strip-unneeded $(OUT_DIR)/fbdepth
-	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(DOOM_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/doom utils/doom.c -lrt
+	$(CC) $(CPPFLAGS) $(EXTRA_CPPFLAGS) $(DOOM_CPPFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(SHARED_CFLAGS) $(LIB_CFLAGS) $(LTO_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) -o$(OUT_DIR)/doom utils/doom.c -lrt $(UTILS_LIBS)
 	$(STRIP) --strip-unneeded $(OUT_DIR)/doom
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,11 @@ ifndef MINIMAL
 	#FEATURES_CPPFLAGS+=-DFBINK_QIS_NO_SIMD
 endif
 
+# We need libdl on PocketBook in order to dlopen InkView...
+ifdef POCKETBOOK
+	LIBS+=-ldl
+endif
+
 ##
 # Now that we're done fiddling with flags, let's build stuff!
 LIB_SRCS:=fbink.c cutef8/utf8.c cutef8/dfa.c

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,9 @@ ifndef CERVANTES
 ifndef LEGACY
 ifndef KINDLE
 ifndef REMARKABLE
+ifndef POCKETBOOK
 	KOBO=true
+endif
 endif
 endif
 endif
@@ -260,6 +262,10 @@ endif
 ifdef REMARKABLE
 	TARGET_CPPFLAGS+=-DFBINK_FOR_REMARKABLE
 endif
+# Toggle PocketBook support
+ifdef POCKETBOOK
+	TARGET_CPPFLAGS+=-DFBINK_FOR_POCKETBOOK
+endif
 
 # And that should definitely be honored by everything, so, add it to EXTRA_CPPFLAGS
 EXTRA_CPPFLAGS+=$(TARGET_CPPFLAGS)
@@ -284,8 +290,12 @@ ifdef FBINK_VERSION
 					ifdef REMARKABLE
 						LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for reMarkable"'
 					else
-						# NOTE: Should never happen!
-						LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION)"'
+						ifdef POCKETBOOK
+							LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION) for PocketBook"'
+						else
+							# NOTE: Should never happen!
+							LIB_CFLAGS+=-DFBINK_VERSION='"$(FBINK_VERSION)"'
+						endif
 					endif
 				endif
 			endif
@@ -587,6 +597,9 @@ cervantes:
 remarkable:
 	$(MAKE) strip REMARKABLE=true
 
+pocketbook:
+	$(MAKE) strip POCKETBOOK=true
+
 libunibreak.built:
 	mkdir -p LibUniBreakBuild
 	cd libunibreak && \
@@ -703,4 +716,4 @@ distclean: clean libunibreakclean
 	rm -rf LibUniBreakBuild
 	rm -rf libunibreak.built
 
-.PHONY: default outdir all staticlib sharedlib static shared striplib striparchive stripbin strip debug static pic shared release kindle legacy cervantes linux armcheck kobo remarkable libunibreakclean utils alt dump clean distclean
+.PHONY: default outdir all staticlib sharedlib static shared striplib striparchive stripbin strip debug static pic shared release kindle legacy cervantes linux armcheck kobo remarkable pocketbook libunibreakclean utils alt dump clean distclean

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is intended to fill the void felt by Kobo developers and tinkerers when the
 It's especially cruel when moving to a Kobo, after being used to the ubiquity of `eips` on Kindle...
 
 In short, it prints messages or images on your screen, handling the low-level tinkering with both the Linux framebuffer interface, and the i.MX EPDC.  
-It's been tested on Kobo, Kindle, BQ Cervantes and reMarkable, but porting it to other Linux, i.MX eInk devices should be trivial (hell, even Sipix support shouldn't be too hard).
+It's been tested on Kobo, Kindle, BQ Cervantes, reMarkable and PocketBook, but porting it to other Linux, i.MX eInk devices should be trivial (hell, even Sipix support shouldn't be too hard).
 
 By default, text rendering relies on bundled fixed cell bitmap fonts ([see this post](https://www.mobileread.com/forums/showpost.php?p=3765426&postcount=31) for a small sampling),
 but thanks to [@shermp](https://github.com/shermp)'s contributions ([#20](https://github.com/NiLuJe/FBInk/pull/20)), you can also rely on full-fledged TrueType/OpenType font rendering!
@@ -89,6 +89,7 @@ The choice of target platform is handled via a simple variable:
 -   Pass `KINDLE=1 LEGACY=1` to make for a FW 2.x Kindle build (`make legacy` does that on a stripped static build). This basically just disables CLOEXEC, which might not be supported on FW 2.x.
 -   Pass `CERVANTES=1` to make for a BQ/Cervantes build (`make cervantes` does that on a stripped static build).
 -   Pass `REMARKABLE=1` to make for a reMarkable build (`make remarkable` does that on a stripped static build).
+-   Pass `POCKETBOOK=1` to make for a PocketBook build (`make pocketbook` does that on a stripped static build).
 
 The same logic is used to allow for a bit of tailoring:
 -   Pass `MINIMAL=1` to make for a build with limited functionality (only fixed cell font rendering, no image rendering, no extra fonts, no OpenType), which yields a much smaller application & library.

--- a/eink/mxcfb-pocketbook-compat.h
+++ b/eink/mxcfb-pocketbook-compat.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2004-2013 Freescale Semiconductor, Inc. All Rights Reserved.
+ */
+
+/*
+ * The code contained herein is licensed under the GNU Lesser General
+ * Public License.  You may obtain a copy of the GNU Lesser General
+ * Public License Version 2.1 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/lgpl-license.html
+ * http://www.gnu.org/copyleft/lgpl.html
+ */
+
+/*
+ * NOTE: Pulled from an EPDCv2 kernel, because we need those constants to build FBInk ;).
+*/
+
+#ifndef __ASM_ARCH_MXCFB_COMPAT_H__
+#define __ASM_ARCH_MXCFB_COMPAT_H__
+
+enum mxcfb_dithering_mode {
+	EPDC_FLAG_USE_DITHERING_PASSTHROUGH = 0x0,
+	EPDC_FLAG_USE_DITHERING_FLOYD_STEINBERG,
+	EPDC_FLAG_USE_DITHERING_ATKINSON,
+	EPDC_FLAG_USE_DITHERING_ORDERED,
+	EPDC_FLAG_USE_DITHERING_QUANT_ONLY,
+	PDC_FLAG_USE_DITHERING_MAX,
+};
+
+#endif // __ASM_ARCH_MXCFB_COMPAT_H__

--- a/eink/mxcfb-pocketbook.h
+++ b/eink/mxcfb-pocketbook.h
@@ -234,11 +234,17 @@ struct mxcfb_csc_matrix {
 
 // NOTE: PB631
 #ifdef MX50_IOCTL_IF//[
-#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB631	_IOW('F', 0x2F, __u32)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB	_IOW('F', 0x2F, __u32)
 #define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB631_V2 _IOWR('F', 0x35, struct mxcfb_update_marker_data)
 #else //][!MX50_IOCTL_IF
 #define MXCFB_WAIT_FOR_UPDATE_COMPLETE_ANDROID _IOWR('F', 0x35, struct mxcfb_update_marker_data)
 #endif//] MX50_IOCTL_IF
+
+// NOTE: Apparently, everything is terrible, and, while kernels appear to always expect the MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB
+//       command, *some* kernels will apparently try to write back as if it were MXCFB_WAIT_FOR_UPDATE_COMPLETE...
+//       The workaround is to actually setup a mxcfb_update_marker_data struct but use MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB.
+//       >_<".
+//       c.f., https://github.com/koreader/koreader-base/pull/1188 & https://github.com/koreader/koreader/pull/6669
 
 #define MXCFB_SET_PWRDOWN_DELAY		_IOW('F', 0x30, int32_t)
 #define MXCFB_GET_PWRDOWN_DELAY		_IOR('F', 0x31, int32_t)

--- a/eink/mxcfb-pocketbook.h
+++ b/eink/mxcfb-pocketbook.h
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2004-2013 Freescale Semiconductor, Inc. All Rights Reserved.
+ */
+
+/*
+ * The code contained herein is licensed under the GNU Lesser General
+ * Public License.  You may obtain a copy of the GNU Lesser General
+ * Public License Version 2.1 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/lgpl-license.html
+ * http://www.gnu.org/copyleft/lgpl.html
+ */
+
+/*
+ * NOTE: Upstream kernels available here: https://github.com/pocketbook/Platform_MX6
+ * - slightly modified (commented out include of fb.h) for Lua integration
+ * - Attempted to frankenstein the two variants together like we do on other platforms...
+*/
+
+/*
+ * @file arch-mxc/   mxcfb.h
+ *
+ * @brief Global header file for the MXC Frame buffer
+ *
+ * @ingroup Framebuffer
+ */
+#ifndef __ASM_ARCH_MXCFB_H__
+#define __ASM_ARCH_MXCFB_H__
+
+//#include <linux/fb.h>
+
+// NOTE: PB631
+#if defined(CONFIG_ANDROID) || defined(ANDROID) //[
+#else //][ !CONFIG_ANDROID||!ANDROID
+	#define MX50_IOCTL_IF	1
+#endif //] !CONFIG_ANDROID
+
+#define FB_SYNC_OE_LOW_ACT	0x80000000
+#define FB_SYNC_CLK_LAT_FALL	0x40000000
+#define FB_SYNC_DATA_INVERT	0x20000000
+#define FB_SYNC_CLK_IDLE_EN	0x10000000
+#define FB_SYNC_SHARP_MODE	0x08000000
+#define FB_SYNC_SWAP_RGB	0x04000000
+#define FB_ACCEL_TRIPLE_FLAG	0x00000000
+#define FB_ACCEL_DOUBLE_FLAG	0x00000001
+
+struct mxcfb_gbl_alpha {
+	int enable;
+	int alpha;
+};
+
+struct mxcfb_loc_alpha {
+	int enable;
+	int alpha_in_pixel;
+	unsigned long alpha_phy_addr0;
+	unsigned long alpha_phy_addr1;
+};
+
+struct mxcfb_color_key {
+	int enable;
+	__u32 color_key;
+};
+
+struct mxcfb_pos {
+	__u16 x;
+	__u16 y;
+};
+
+struct mxcfb_gamma {
+	int enable;
+	int constk[16];
+	int slopek[16];
+};
+
+struct mxcfb_rect {
+	__u32 top;
+	__u32 left;
+	__u32 width;
+	__u32 height;
+};
+
+#define GRAYSCALE_8BIT				0x1
+#define GRAYSCALE_8BIT_INVERTED			0x2
+#define GRAYSCALE_4BIT                          0x3
+#define GRAYSCALE_4BIT_INVERTED                 0x4
+
+#define AUTO_UPDATE_MODE_REGION_MODE		0
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE		1
+
+#define UPDATE_SCHEME_SNAPSHOT			0
+#define UPDATE_SCHEME_QUEUE			1
+#define UPDATE_SCHEME_QUEUE_AND_MERGE		2
+
+#define UPDATE_MODE_PARTIAL			0x0
+#define UPDATE_MODE_FULL			0x1
+
+// NOTE: PB631
+#define UPDATE_MODE_PARTIALHQ			0x2
+// PARTIALHQ || PARTIAL + GC16HQ => FULL + AA
+#define UPDATE_MODE_FULLHQ			0x3
+// FULLHQ || FULL + GC16HQ => FULL + AAD
+
+// NOTE: Buried in drivers/video/mxc/mxc_epdc_fb.c
+//       PB only defines DU, A2, A2IN & A2OUT
+#define EPDC_WFTYPE_INIT			0
+#define EPDC_WFTYPE_DU				1
+#define EPDC_WFTYPE_GC16			2
+#define EPDC_WFTYPE_GC4				3
+#define EPDC_WFTYPE_A2				4
+#define EPDC_WFTYPE_GL16			5
+#define EPDC_WFTYPE_A2IN			6
+#define EPDC_WFTYPE_A2OUT			7
+#define EPDC_WFTYPE_DU4				8
+#define EPDC_WFTYPE_AA				9
+#define EPDC_WFTYPE_AAD				10
+#define EPDC_WFTYPE_GC16HQ			15
+// NOTE: Alias that to our usual constant names...
+#define WAVEFORM_MODE_INIT			EPDC_WFTYPE_INIT
+#define WAVEFORM_MODE_DU			EPDC_WFTYPE_DU
+#define WAVEFORM_MODE_GC16			EPDC_WFTYPE_GC16
+#define WAVEFORM_MODE_GC4			EPDC_WFTYPE_GC4
+#define WAVEFORM_MODE_A2			EPDC_WFTYPE_A2
+#define WAVEFORM_MODE_GL16			EPDC_WFTYPE_GL16
+#define WAVEFORM_MODE_A2IN			EPDC_WFTYPE_A2IN
+#define WAVEFORM_MODE_A2OUT			EPDC_WFTYPE_A2OUT
+#define WAVEFORM_MODE_DU4			EPDC_WFTYPE_DU4
+#define WAVEFORM_MODE_REAGL			EPDC_WFTYPE_AA
+#define WAVEFORM_MODE_REAGLD			EPDC_WFTYPE_AAD
+#define WAVEFORM_MODE_GC16HQ			EPDC_WFTYPE_GC16HQ
+
+#define WAVEFORM_MODE_AUTO			257
+
+#define TEMP_USE_AMBIENT			0x1000
+
+#define EPDC_FLAG_ENABLE_INVERSION		0x01
+#define EPDC_FLAG_FORCE_MONOCHROME		0x02
+#define EPDC_FLAG_USE_CMAP			0x04
+#define EPDC_FLAG_USE_ALT_BUFFER		0x100
+#define EPDC_FLAG_TEST_COLLISION		0x200
+#define EPDC_FLAG_GROUP_UPDATE			0x400
+
+// NOTE: PB631
+#define EPDC_FLAG_USE_AAD			0x1000
+
+#define EPDC_FLAG_USE_DITHERING_Y1		0x2000
+#define EPDC_FLAG_USE_DITHERING_Y4		0x4000
+
+// NOTE: PB631
+#define EPDC_FLAG_USE_DITHERING_NTX_D8		0x100000
+
+#define FB_POWERDOWN_DISABLE			-1
+
+// NOTE: The virt_addr mess that we mercifully don't have to deal with is from PB631
+struct mxcfb_alt_buffer_data {
+//#if defined(CONFIG_ANDROID) || defined (ANDROID)//[
+//#else//][!CONFIG_ANDROID
+//	void *virt_addr;
+//#endif//]!CONFIG_ANDROID
+	__u32 phys_addr;
+	__u32 width;	/* width of entire buffer */
+	__u32 height;	/* height of entire buffer */
+	struct mxcfb_rect alt_update_region;	/* region within buffer to update */
+};
+
+struct mxcfb_update_data {
+	struct mxcfb_rect update_region;
+	__u32 waveform_mode;
+	__u32 update_mode;
+	__u32 update_marker;
+	int temp;
+	unsigned int flags;
+	struct mxcfb_alt_buffer_data alt_buffer_data;
+};
+
+struct mxcfb_update_marker_data {
+	__u32 update_marker;
+	__u32 collision_test;
+};
+
+/*
+ * Structure used to define waveform modes for driver
+ * Needed for driver to perform auto-waveform selection
+ */
+struct mxcfb_waveform_modes {
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc32;
+	// NOTE: PB631
+	int mode_aa;
+	int mode_aad;
+	int mode_gl16;
+	int mode_a2;
+	int mode_a2in;
+	int mode_a2out;
+};
+
+/*
+ * Structure used to define a 5*3 matrix of parameters for
+ * setting IPU DP CSC module related to this framebuffer.
+ */
+struct mxcfb_csc_matrix {
+	int param[5][3];
+};
+
+#define MXCFB_WAIT_FOR_VSYNC	_IOW('F', 0x20, u_int32_t)
+#define MXCFB_SET_GBL_ALPHA     _IOW('F', 0x21, struct mxcfb_gbl_alpha)
+#define MXCFB_SET_CLR_KEY       _IOW('F', 0x22, struct mxcfb_color_key)
+#define MXCFB_SET_OVERLAY_POS   _IOWR('F', 0x24, struct mxcfb_pos)
+#define MXCFB_GET_FB_IPU_CHAN 	_IOR('F', 0x25, u_int32_t)
+#define MXCFB_SET_LOC_ALPHA     _IOWR('F', 0x26, struct mxcfb_loc_alpha)
+#define MXCFB_SET_LOC_ALP_BUF    _IOW('F', 0x27, unsigned long)
+#define MXCFB_SET_GAMMA	       _IOW('F', 0x28, struct mxcfb_gamma)
+#define MXCFB_GET_FB_IPU_DI 	_IOR('F', 0x29, u_int32_t)
+#define MXCFB_GET_DIFMT	       _IOR('F', 0x2A, u_int32_t)
+#define MXCFB_GET_FB_BLANK     _IOR('F', 0x2B, u_int32_t)
+#define MXCFB_SET_DIFMT		_IOW('F', 0x2C, u_int32_t)
+
+// NOTE: PB631
+#define MXCFB_ENABLE_VSYNC_EVENT	_IOW('F', 0x33, int32_t)
+
+#define MXCFB_CSC_UPDATE	_IOW('F', 0x2D, struct mxcfb_csc_matrix)
+
+/* IOCTLs for E-ink panel updates */
+#define MXCFB_SET_WAVEFORM_MODES	_IOW('F', 0x2B, struct mxcfb_waveform_modes)
+#define MXCFB_SET_TEMPERATURE		_IOW('F', 0x2C, int32_t)
+#define MXCFB_SET_AUTO_UPDATE_MODE	_IOW('F', 0x2D, __u32)
+#define MXCFB_SEND_UPDATE		_IOW('F', 0x2E, struct mxcfb_update_data)
+
+// NOTE: PB
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE _IOWR('F', 0x2F, struct mxcfb_update_marker_data)
+
+// NOTE: PB631
+#ifdef MX50_IOCTL_IF//[
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB631	_IOW('F', 0x2F, __u32)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB631_V2 _IOWR('F', 0x35, struct mxcfb_update_marker_data)
+#else //][!MX50_IOCTL_IF
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_ANDROID _IOWR('F', 0x35, struct mxcfb_update_marker_data)
+#endif//] MX50_IOCTL_IF
+
+#define MXCFB_SET_PWRDOWN_DELAY		_IOW('F', 0x30, int32_t)
+#define MXCFB_GET_PWRDOWN_DELAY		_IOR('F', 0x31, int32_t)
+#define MXCFB_SET_UPDATE_SCHEME		_IOW('F', 0x32, __u32)
+#define MXCFB_GET_WORK_BUFFER		_IOWR('F', 0x34, unsigned long)
+
+#ifdef __KERNEL__
+
+extern struct fb_videomode mxcfb_modedb[];
+extern int mxcfb_modedb_sz;
+
+enum {
+	MXC_DISP_SPEC_DEV = 0,
+	MXC_DISP_DDC_DEV = 1,
+};
+
+enum {
+	MXCFB_REFRESH_OFF,
+	MXCFB_REFRESH_AUTO,
+	MXCFB_REFRESH_PARTIAL,
+};
+
+int mxcfb_set_refresh_mode(struct fb_info *fbi, int mode,
+			   struct mxcfb_rect *update_region);
+int mxc_elcdif_frame_addr_setup(dma_addr_t phys);
+void mxcfb_elcdif_register_mode(const struct fb_videomode *modedb,
+		int num_modes, int dev_mode);
+
+#endif				/* __KERNEL__ */
+#endif

--- a/fbink.c
+++ b/fbink.c
@@ -2273,11 +2273,14 @@ static int
 static int
     wait_for_complete_pocketbook(int fbfd, uint32_t marker)
 {
+	// NOTE: Yes, some kernels will attempt to write back to the struct,
+	//       despite using an ioctl that should only read an uint32_t...
+	//       c.f., https://github.com/koreader/koreader/pull/6669
 	struct mxcfb_update_marker_data update_data = { .update_marker = marker, .collision_test = 0U };
-	int                             rv          = ioctl(fbfd, MXCFB_WAIT_FOR_UPDATE_COMPLETE, &update_data);
+	int                             rv          = ioctl(fbfd, MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB, &update_data);
 
 	if (rv < 0) {
-		PFWARN("MXCFB_WAIT_FOR_UPDATE_COMPLETE: %m");
+		PFWARN("MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB: %m");
 		return ERRCODE(EXIT_FAILURE);
 	} else {
 		if (rv == 0) {

--- a/fbink.c
+++ b/fbink.c
@@ -3353,6 +3353,11 @@ static int
 		     screenWidth,
 		     screenHeight);
 	}
+
+	viewWidth = screenWidth;
+	viewHoriOrigin = 0U;
+	viewHeight = screenHeight;
+	viewVertOrigin = 0U;
 #else
 	// Other devices are generally never broken-by-design (at least not on that front ;))
 	viewWidth      = screenWidth;

--- a/fbink.c
+++ b/fbink.c
@@ -193,7 +193,7 @@ static inline __attribute__((always_inline)) void
 #pragma GCC diagnostic pop
 }
 
-#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES) || defined(FBINK_FOR_POCKETBOOK)
 // Handle rotation quirks...
 static void
     rotate_coordinates_pickel(FBInkCoordinates* restrict coords)
@@ -250,7 +250,9 @@ static void
 	coords->y = ry;
 #	endif
 }
+#endif    // FBINK_FOR_KOBO || FBINK_FOR_CERVANTES || FBINK_FOR_POCKETBOOK
 
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
 static void
     rotate_coordinates_boot(FBInkCoordinates* restrict coords)
 {
@@ -4121,7 +4123,7 @@ int
 
 // Much like rotate_coordinates, but for a mxcfb rectangle
 // c.f., adjust_coordinates @ drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c
-#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES) || defined(FBINK_FOR_POCKETBOOK)
 static void
     rotate_region_pickel(struct mxcfb_rect* restrict region)
 {
@@ -4133,7 +4135,9 @@ static void
 	region->width  = oregion.height;
 	region->height = oregion.width;
 }
+#endif    // FBINK_FOR_KOBO || FBINK_FOR_CERVANTES || FBINK_FOR_POCKETBOOK
 
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
 static void
     rotate_region_boot(struct mxcfb_rect* restrict region)
 {

--- a/fbink.c
+++ b/fbink.c
@@ -3058,6 +3058,7 @@ static void
 static void
     pocketbook_fix_fb_info(void)
 {
+	ELOG("Virtual resolution: %ux%u", vInfo.xres_virtual, vInfo.yres_virtual);
 	// Not duplicating all the explanations here, c.f., the KOReader snippet linked earlier ;).
 	if (fInfo.id[0] == '\0') {
 		uint32_t xres_virtual = vInfo.xres_virtual;

--- a/fbink.c
+++ b/fbink.c
@@ -3334,11 +3334,28 @@ static int
 		viewHeight     = screenHeight;
 		viewVertOrigin = 0U;
 	}
+#elif defined(FBINK_FOR_POCKETBOOK)
+	// NOTE: Some PocketBook devices have their panel mounted sideways, like the NTX boards we handled above...
+	//       I'm *hoping* this is enough to do the trick, without having to resort to a deviceQuirks flag,
+	//       which is essentially how this is handled in KOReader (via isAlwaysPortrait).
+	//       Obviously, the broadness of this check severely limits the possibility of actually handling hardware rotations
+	//       sanely, but for now, we only want to deal with the default rotation properly...
+	if (vInfo.xres > vInfo.yres) {
+		screenWidth = vInfo.yres;
+		screenHeight = vInfo.xres;
+		fxpRotateCoords = &rotate_coordinates_pickel;
+		fxpRotateRegion = &rotate_region_pickel;
+		ELOG("Enabled PocketBook rotation quirks (%ux%u -> %ux%u)",
+		     vInfo.xres,
+		     vInfo.yres,
+		     screenWidth,
+		     screenHeight);
+	}
 #else
 	// Other devices are generally never broken-by-design (at least not on that front ;))
-	viewWidth = screenWidth;
+	viewWidth      = screenWidth;
 	viewHoriOrigin = 0U;
-	viewHeight = screenHeight;
+	viewHeight     = screenHeight;
 	viewVertOrigin = 0U;
 #endif
 

--- a/fbink.c
+++ b/fbink.c
@@ -3335,7 +3335,7 @@ static int
 		viewVertOrigin = 0U;
 	}
 #else
-	// Kindle devices are generally never broken-by-design (at least not on that front ;))
+	// Other devices are generally never broken-by-design (at least not on that front ;))
 	viewWidth = screenWidth;
 	viewHoriOrigin = 0U;
 	viewHeight = screenHeight;

--- a/fbink.h
+++ b/fbink.h
@@ -218,6 +218,9 @@ typedef enum
 	WFM_INIT,
 	WFM_UNKNOWN,
 	WFM_INIT2,
+	WFM_A2IN,
+	WFM_A2OUT,
+	WFM_GC16HQ,
 	WFM_MAX = 0xFFu,    // uint8_t
 } __attribute__((packed)) WFM_MODE_INDEX_E;
 typedef uint8_t WFM_MODE_INDEX_T;

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -124,10 +124,10 @@ static void
 #	if defined(FBINK_FOR_KINDLE)
 	    "\t\t\t\tAs well as REAGL, REAGLD, GC16_FAST, GL16_FAST, DU4, GL4, GL16_INV, GCK16 & GLKW16 on some Kindles, depending on the model & FW version.\n"
 	    "\t\t\t\tNote that specifying a waveform mode is ignored on legacy einkfb devices, because the hardware doesn't expose such capabilities.\n"
-#	elif !defined(FBINK_FOR_REMARKABLE)
-	    "\t\t\t\tAs well as GC4, REAGL & REAGLD.\n"
-#	elif !defined(FBINK_FOR_POCKETBOOK)
+#	elif defined(FBINK_FOR_POCKETBOOK)
 	    "\t\t\t\tAs well as GC4, A2IN, A2OUT, DU4, REAGL, REAGLD & GC16HQ.\n"
+#	elif defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
+	    "\t\t\t\tAs well as GC4, REAGL & REAGLD.\n"
 #	endif
 #	if !defined(FBINK_FOR_REMARKABLE)
 	    "\t\t\t\tUnsupported modes should safely downgrade to AUTO. On some devices, REAGL & REAGLD expect to be flashing in order to behave properly.\n"

--- a/fbink_cmd.c
+++ b/fbink_cmd.c
@@ -126,6 +126,8 @@ static void
 	    "\t\t\t\tNote that specifying a waveform mode is ignored on legacy einkfb devices, because the hardware doesn't expose such capabilities.\n"
 #	elif !defined(FBINK_FOR_REMARKABLE)
 	    "\t\t\t\tAs well as GC4, REAGL & REAGLD.\n"
+#	elif !defined(FBINK_FOR_POCKETBOOK)
+	    "\t\t\t\tAs well as GC4, A2IN, A2OUT, DU4, REAGL, REAGLD & GC16HQ.\n"
 #	endif
 #	if !defined(FBINK_FOR_REMARKABLE)
 	    "\t\t\t\tUnsupported modes should safely downgrade to AUTO. On some devices, REAGL & REAGLD expect to be flashing in order to behave properly.\n"
@@ -1641,6 +1643,12 @@ int
 					fbink_cfg.wfm_mode = WFM_UNKNOWN;
 				} else if (strcasecmp(optarg, "INIT2") == 0) {
 					fbink_cfg.wfm_mode = WFM_INIT2;
+				} else if (strcasecmp(optarg, "A2IN") == 0) {
+					fbink_cfg.wfm_mode = WFM_A2IN;
+				} else if (strcasecmp(optarg, "A2OUT") == 0) {
+					fbink_cfg.wfm_mode = WFM_A2OUT;
+				} else if (strcasecmp(optarg, "GC16HQ") == 0) {
+					fbink_cfg.wfm_mode = WFM_GC16HQ;
 				} else {
 					ELOG("Unknown waveform update mode '%s'.", optarg);
 					errfnd = true;

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -983,7 +983,7 @@ static void
 			inkview_GetDeviceModel                = dlsym(inkview, "GetDeviceModel");
 
 			char* err = dlerror();
-			if (error != NULL) {
+			if (err != NULL) {
 				ELOG("Failed to obtain GetDeviceModel symbol: %s", err);
 			} else {
 				// NOTE: We may be leaking the string here, since I have no idea what InkView does...
@@ -997,15 +997,129 @@ static void
 		}
 	}
 
+	// Unless otherwise specified, let's allow HW inversion everywhere for now...
+	deviceQuirks.canHWInvert = true;
+
 	if (model_name) {
-		// TODO: Model name dance!
+		// Keep the model name dance in the same order as KOReader...
+		if (strcmp(model_name, "PocketBook 515") == 0) {
+			deviceQuirks.screenDPI = 200U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PB515", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB606") == 0 || strcmp(model_name, "PocketBook 606") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PB606", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 611") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PB611", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 613") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PB613B", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 614") == 0 || strcmp(model_name, "PocketBook 614W") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PB614W", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB615") == 0 || strcmp(model_name, "PB615W") == 0 ||
+			   strcmp(model_name, "PocketBook 615") == 0 || strcmp(model_name, "PocketBook 615W") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBBLux", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB616") == 0 || strcmp(model_name, "PB616W") == 0 ||
+			   strcmp(model_name, "PocketBook 616") == 0 || strcmp(model_name, "PocketBook 616W") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBBLux2", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 622") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBTouch", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 623") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBTouchLux", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 624") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBBTouch", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB625") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBBTouch2", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB626") == 0 || strcmp(model_name, "PB626(2)-TL3") == 0 ||
+			   strcmp(model_name, "PocketBook 626") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBLux3", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB627") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBLux4", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB628") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBLux5", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 630") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBSense", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB631") == 0 || strcmp(model_name, "PocketBook 631") == 0) {
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBTouchHD", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB632") == 0) {
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBTouchHD+", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB633") == 0) {
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBColor", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB640") == 0 || strcmp(model_name, "PocketBook 640") == 0) {
+			deviceQuirks.screenDPI = 167U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBAqua", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB641") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBAqua2", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB650") == 0 || strcmp(model_name, "PocketBook 650") == 0) {
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBUltra", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB740") == 0) {
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBInkPad3", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB740-2") == 0) {
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBInkPad3Pro", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook 840") == 0) {
+			deviceQuirks.screenDPI = 250U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBInkPad", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PB1040") == 0) {
+			deviceQuirks.screenDPI = 227U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PB1040", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else if (strcmp(model_name, "PocketBook Color Lux") == 0) {
+			deviceQuirks.screenDPI          = 125U;
+			deviceQuirks.isPB3BytesPerPixel = true;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "PBColorLux", sizeof(deviceQuirks.deviceCodename) - 1U);
+		} else {
+			WARN("Unidentified PocketBook model: `%s`", model_name);
+			deviceQuirks.screenDPI = 212U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "Unidentified", sizeof(deviceQuirks.deviceCodename) - 1U);
+		}
 	} else {
 		// NOTE: Failed to query DeviceModel via InkView, so, fake something...
-		deviceQuirks.screenDPI   = 226;
-		deviceQuirks.canHWInvert = true;
-
-		// Flawfinder: ignore
-		strncpy(deviceQuirks.deviceName, "Unidentified", sizeof(deviceQuirks.deviceName) - 1U);
+		WARN("Couldn't query PocketBook model name via InkView");
+		deviceQuirks.screenDPI = 212U;
 		// Flawfinder: ignore
 		strncpy(deviceQuirks.deviceCodename, "Unknown", sizeof(deviceQuirks.deviceCodename) - 1U);
 	}

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -968,14 +968,45 @@ static void
 static void
     identify_pocketbook(void)
 {
-	// FIXME: I'd *really* like to avoid calling InkView here, so, fake it for now...
-	deviceQuirks.screenDPI   = 226;
-	deviceQuirks.canHWInvert = true;
+	char* model_name = NULL;
+	// NOTE: I'm not super happy about calling InkView here,
+	//       so do it in a slightly roundabout way to try to prevent it from wreaking too much havoc...
+	void* inkview = dlopen("libinkview.so", RTLD_LAZY | RTLD_LOCAL);
+	if (!inkview) {
+		ELOG("Failed to load InkView: %s", dlerror());
+	} else {
+		dlerror();
 
-	// Flawfinder: ignore
-	strncpy(deviceQuirks.deviceName, "PocketBook", sizeof(deviceQuirks.deviceName) - 1U);
-	// Flawfinder: ignore
-	strncpy(deviceQuirks.deviceCodename, "Unknown", sizeof(deviceQuirks.deviceCodename) - 1U);
+		// Try to grab the adress for InkView's GetDeviceModel function...
+		char* (*inkview_GetDeviceModel)(void) = NULL;
+		inkview_GetDeviceModel                = dlsym(inkview, "GetDeviceModel");
+
+		char* err = dlerror();
+		if (error != NULL) {
+			ELOG("Failed to obtain GetDeviceModel symbol: %s", err);
+		} else {
+			// NOTE: We may be leaking the string here, since I have no idea what InkView does...
+			char* model = (*inkview_GetDeviceModel)();
+			//       Which is why we make a copy, just in case...
+			model_name = strdupa(model);
+		}
+
+		// Bye InkView! Hopefully your crappy dependencies haven't wreaked too much havoc...
+		dlclose(inkview);
+	}
+
+	if (model_name) {
+		// TODO: Model name dance!
+	} else {
+		// NOTE: Failed to query DeviceModel via InkView, so, fake something...
+		deviceQuirks.screenDPI   = 226;
+		deviceQuirks.canHWInvert = true;
+
+		// Flawfinder: ignore
+		strncpy(deviceQuirks.deviceName, "Unidentified", sizeof(deviceQuirks.deviceName) - 1U);
+		// Flawfinder: ignore
+		strncpy(deviceQuirks.deviceCodename, "Unknown", sizeof(deviceQuirks.deviceCodename) - 1U);
+	}
 }
 #	endif    // FBINK_FOR_KINDLE
 

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -964,6 +964,19 @@ static void
 	// Flawfinder: ignore
 	strncpy(deviceQuirks.deviceCodename, "Zero Gravitas", sizeof(deviceQuirks.deviceCodename) - 1U);
 }
+#	elif defined(FBINK_FOR_POCKETBOOK)
+static void
+    identify_pocketbook(void)
+{
+	// FIXME: I'd *really* like to avoid calling InkView here, so, fake it for now...
+	deviceQuirks.screenDPI   = 226;
+	deviceQuirks.canHWInvert = true;
+
+	// Flawfinder: ignore
+	strncpy(deviceQuirks.deviceName, "PocketBook", sizeof(deviceQuirks.deviceName) - 1U);
+	// Flawfinder: ignore
+	strncpy(deviceQuirks.deviceCodename, "Unknown", sizeof(deviceQuirks.deviceCodename) - 1U);
+}
 #	endif    // FBINK_FOR_KINDLE
 
 static void
@@ -1006,6 +1019,9 @@ static void
 #	elif defined(FBINK_FOR_REMARKABLE)
 	identify_remarkable();
 	ELOG("Detected a reMarkable (%s)", deviceQuirks.deviceCodename);
+#	elif defined(FBINK_FOR_POCKETBOOK)
+	identify_pocketbook();
+	ELOG("Detected a PocketBook (%s)", deviceQuirks.deviceCodename);
 #	endif
 	// Warn if canHWInvert was flipped
 	if (!deviceQuirks.canHWInvert) {

--- a/fbink_device_id.h
+++ b/fbink_device_id.h
@@ -146,6 +146,8 @@ static void set_kobo_quirks(unsigned short int);
 static void identify_kobo(void);
 #        elif defined(FBINK_FOR_REMARKABLE)
 static void identify_remarkable(void);
+#        elif defined(FBINK_FOR_POCKETBOOK)
+static void identify_pocketbook(void);
 #        endif    // FBINK_FOR_KINDLE
 
 static void identify_device(void);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -304,6 +304,19 @@
 		(x__ > y__) ? x__ : y__;                                                                                 \
 	})
 
+// We'll need those on PocketBook...
+// c.f., <linux/kernel.h>
+#define ALIGN(x, a)                                                                                                      \
+	({                                                                                                               \
+		__auto_type mask__ = (a) -1U;                                                                            \
+		(((x) + (mask__)) & ~(mask__));                                                                          \
+	})
+#define IS_ALIGNED(x, a)                                                                                                 \
+	({                                                                                                               \
+		__auto_type mask__ = (a) -1U;                                                                            \
+		((x) & (mask__)) == 0 ? true : false;                                                                    \
+	})
+
 // NOTE: Some of our ifdef combinations may cause a small number of function arguments to become unused...
 //       Handle the warnings in these cases with a bit of trickery,
 //       by conditionally marking theses arguments as unused ;).
@@ -641,7 +654,10 @@ static const char* einkfb_orientation_to_string(orientation_t);
 static int  set_pen_color(bool, bool, bool, bool, uint8_t, uint8_t, uint8_t, uint8_t);
 static int  update_pen_colors(const FBInkConfig* restrict);
 static void update_verbosity(const FBInkConfig* restrict);
-static int  initialize_fbink(int, const FBInkConfig* restrict, bool);
+#ifdef FBINK_FOR_POCKETBOOK
+static void pocketbook_fix_fb_info(void);
+#endif
+static int initialize_fbink(int, const FBInkConfig* restrict, bool);
 
 static int memmap_fb(int);
 static int unmap_fb(void);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -193,6 +193,8 @@
 #elif defined(FBINK_FOR_POCKETBOOK)
 #	include "eink/mxcfb-pocketbook.h"
 #	include "eink/mxcfb-pocketbook-compat.h"
+// We'll try to avoid being tainted by InkView as much as possible...
+#	include <dlfcn.h>
 #elif defined(FBINK_FOR_LINUX)
 // Fallback, because, even on straight Linux, we require a few mxcfb typedefs for some of our own function prototypes...
 #	include "eink/mxcfb-kobo.h"

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -29,7 +29,9 @@
 #		ifndef FBINK_FOR_LINUX
 #			ifndef FBINK_FOR_KOBO
 #				ifndef FBINK_FOR_REMARKABLE
-#					define FBINK_FOR_KOBO
+#					ifndef FBINK_FOR_POCKETBOOK
+#						define FBINK_FOR_KOBO
+#					endif
 #				endif
 #			endif
 #		endif
@@ -188,6 +190,8 @@
 #	include "eink/mxcfb-kobo.h"
 #elif defined(FBINK_FOR_REMARKABLE)
 #	include "eink/mxcfb-remarkable.h"
+#elif defined(FBINK_FOR_POCKETBOOK)
+#	include "eink/mxcfb-pocketbook.h"
 #elif defined(FBINK_FOR_LINUX)
 // Fallback, because, even on straight Linux, we require a few mxcfb typedefs for some of our own function prototypes...
 #	include "eink/mxcfb-kobo.h"
@@ -265,13 +269,17 @@
 #			ifdef FBINK_FOR_REMARKABLE
 #				define FBINK_VERSION FBINK_FALLBACK_VERSION " for reMarkable"
 #			else
-#				ifdef FBINK_FOR_LINUX
-#					define FBINK_VERSION FBINK_FALLBACK_VERSION " for Linux"
+#				ifdef FBINK_FOR_POCKETBOOK
+#					define FBINK_VERSION FBINK_FALLBACK_VERSION " for PocketBook"
 #				else
-#					ifdef FBINK_FOR_KOBO
-#						define FBINK_VERSION FBINK_FALLBACK_VERSION " for Kobo"
+#					ifdef FBINK_FOR_LINUX
+#						define FBINK_VERSION FBINK_FALLBACK_VERSION " for Linux"
 #					else
-#						define FBINK_VERSION FBINK_FALLBACK_VERSION
+#						ifdef FBINK_FOR_KOBO
+#							define FBINK_VERSION FBINK_FALLBACK_VERSION " for Kobo"
+#						else
+#							define FBINK_VERSION FBINK_FALLBACK_VERSION
+#						endif
 #					endif
 #				endif
 #			endif
@@ -325,6 +333,11 @@
 #	define UNUSED_BY_REMARKABLE __attribute__((unused))
 #else
 #	define UNUSED_BY_REMARKABLE
+#endif
+#ifdef FBINK_FOR_POCKETBOOK
+#	define UNUSED_BY_POCKETBOOK __attribute__((unused))
+#else
+#	define UNUSED_BY_POCKETBOOK
 #endif
 #ifndef FBINK_FOR_LINUX
 #	define UNUSED_BY_NOTLINUX __attribute__((unused))
@@ -600,6 +613,9 @@ static int wait_for_complete_cervantes(int, uint32_t);
 #	elif defined(FBINK_FOR_REMARKABLE)
 static int refresh_remarkable(int, const struct mxcfb_rect, uint32_t, uint32_t, int, bool, uint32_t);
 static int wait_for_complete_remarkable(int, uint32_t);
+#	elif defined(FBINK_FOR_POCKETBOOK)
+static int refresh_pocketbook(int, const struct mxcfb_rect, uint32_t, uint32_t, int, bool, uint32_t);
+static int wait_for_complete_pocketbook(int, uint32_t);
 #	elif defined(FBINK_FOR_KOBO)
 static int refresh_kobo(int, const struct mxcfb_rect, uint32_t, uint32_t, int, bool, uint32_t);
 static int wait_for_complete_kobo(int, uint32_t);
@@ -681,6 +697,9 @@ static const char* ntx_wfm_to_string(uint32_t);
 #	endif
 #	ifdef FBINK_FOR_REMARKABLE
 static const char* remarkable_wfm_to_string(uint32_t);
+#	endif
+#	ifdef FBINK_FOR_POCKETBOOK
+static const char* pocketbook_wfm_to_string(uint32_t);
 #	endif
 #endif
 static int         get_hwd_mode(uint8_t);

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -192,6 +192,7 @@
 #	include "eink/mxcfb-remarkable.h"
 #elif defined(FBINK_FOR_POCKETBOOK)
 #	include "eink/mxcfb-pocketbook.h"
+#	include "eink/mxcfb-pocketbook-compat.h"
 #elif defined(FBINK_FOR_LINUX)
 // Fallback, because, even on straight Linux, we require a few mxcfb typedefs for some of our own function prototypes...
 #	include "eink/mxcfb-kobo.h"

--- a/fbink_internal.h
+++ b/fbink_internal.h
@@ -486,8 +486,10 @@ bool         otInit  = false;
 FBInkOTFonts otFonts = { NULL, NULL, NULL, NULL };
 #endif
 
-#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES) || defined(FBINK_FOR_POCKETBOOK)
 static void rotate_coordinates_pickel(FBInkCoordinates* restrict);
+#endif
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
 static void rotate_coordinates_boot(FBInkCoordinates* restrict);
 #	ifdef FBINK_WITH_BUTTON_SCAN
 static void rotate_touch_coordinates(FBInkCoordinates* restrict);
@@ -665,8 +667,10 @@ static int initialize_fbink(int, const FBInkConfig* restrict, bool);
 static int memmap_fb(int);
 static int unmap_fb(void);
 
-#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES) || defined(FBINK_FOR_POCKETBOOK)
 static void rotate_region_pickel(struct mxcfb_rect* restrict);
+#endif
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
 static void rotate_region_boot(struct mxcfb_rect* restrict);
 #endif
 static void rotate_region_nop(struct mxcfb_rect* restrict);

--- a/fbink_types.h
+++ b/fbink_types.h
@@ -53,6 +53,7 @@ typedef struct
 	NTX_ROTA_INDEX_T   ntxRotaQuirk;
 	bool               canRotate;
 	bool               canHWInvert;
+	bool               isPB3BytesPerPixel;
 	bool               skipId;
 } FBInkDeviceQuirks;
 

--- a/utils/fbdepth.c
+++ b/utils/fbdepth.c
@@ -265,13 +265,17 @@ static bool
 	//       c.f., mxc_epdc_fb_check_var @ drivers/video/mxc/mxc_epdc_fb.c OR drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c
 	//       The goal being to end up in the *same* effective rotation as before.
 	// First, remember the current rotation as the expected one...
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES) || defined(FBINK_FOR_KINDLE)
 	uint32_t expected_rota = vInfo.rotate;
+#endif
 	// Then, set the requested rotation, if there was one...
 	if (rota != -1) {
 		vInfo.rotate = (uint32_t) rota;
 		LOG("Setting rotate to %u (%s)", vInfo.rotate, fb_rotate_to_string(vInfo.rotate));
 		// And flag it as the expected rota for the sanity checks
+#if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES) || defined(FBINK_FOR_KINDLE)
 		expected_rota = (uint32_t) rota;
+#endif
 	}
 #if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
 	if (deviceQuirks.ntxRotaQuirk == NTX_ROTA_ALL_INVERTED) {


### PR DESCRIPTION
This has been bothering me for quite a while, and given the work & progress done in KOReader thanks to @ezdiy & @pazos, I figured it was finally time to give it a final push over the finish line ;).

Obviously, I still don't have a PB to test, so I could only vaguely check that it didn't horribly implode ^^.

In particular, I tried something as regards device identification to avoid a hard-dependency on InkView, hoping that this would help alleviate the various issues we've had with its crappy initialization and old dependencies in KOReader...
Since I'm not *quite* sure it'll necessarily help in every case, InkView handling can be disabled entirely at runtime by setting `FBINK_NO_INKVIEW` in the env.
The only thing we actually "need" device identification for is basically just setting a fancy codename and choosing the right DPI, so it's not the end of the world if we get it wrong.
(The only real exception being the weird Color Lux, which is broken by default if we can't ID it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/niluje/fbink/47)
<!-- Reviewable:end -->
