### PR TITLE
Command line documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,10 +15,10 @@
   Print image on your device's screen.
 
 * ```sh
-  fbink [-WHf] [-k] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]
+  fbink [-WHf] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]
   ```
 
-  Refresh the screen (or a region of it).
+  Refresh the screen as per your specification, without touching the framebuffer.
 
 * ```sh
   fbink [-BhHWDbw] --cls [top=NUM,left=NUM,width=NUM,height=NUM]

--- a/API.md
+++ b/API.md
@@ -354,25 +354,29 @@
 
   Honors `-h`, `--invert`; `-f`, `--flash`; `-c`, `--clear`; `-W`, `--waveform`; `-D`, `--dither`; `-H`, `--nightmode`; `-b`, `--norefresh`; `-m`, `--centered`; `-M`, `--halfway`; `-o`, `--overlay`; `-T`, `--fgless`; `-O`, `--bgless`; `-C`, `--color`; `-B`, `--background`; `-l`, `--linecount`.
 
-  Examples:
+  Example:
 
-  * For Kindle:
-
-    ```sh
-    fbink -t regular=/usr/java/lib/fonts/Caecilia_LT_65_Medium.ttf,bold=/usr/java/lib/fonts/Caecilia_LT_75_Bold.ttf,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
+  * ```sh
+    fbink -t regular=$RFONT,bold=$BFONT,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
     ```
 
-    Will use Caecilia to print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
+    Will print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
 
-  * For other than Kindle:
+    For Kindle try:
 
     ```sh
-    fbink -t regular=/mnt/onboard/fonts/NotoSans-Regular.ttf,bold=/mnt/onboard/fonts/NotoSans-Bold.ttf,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
+    RFONT=/usr/java/lib/fonts/Caecilia_LT_65_Medium.ttf
+    BFONT=/usr/java/lib/fonts/Caecilia_LT_75_Bold.ttf
     ```
 
-    Will use NotoSans to print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
+    And others (other than Kobo):
 
-  * Note for Kobo: this means you will NOT be able to use system fonts on Kobo, because they're all obfuscated.
+    ```sh
+    RFONT=/mnt/onboard/fonts/NotoSans-Regular.ttf
+    BFONT=/mnt/onboard/fonts/NotoSans-Bold.ttf
+    ```
+
+    Note for Kobo: this means you will NOT be able to use system fonts on Kobo, because they're all obfuscated.
 
 ### Options for printing an image (if compiled with `FBINK_WITH_IMAGE`)
 

--- a/API.md
+++ b/API.md
@@ -1,0 +1,385 @@
+# FBInk Command Line App Manual
+
+## Synopsis
+
+* ```sh
+  fbink [OPTIONS] [STRING ...]
+  ```
+
+  Print `STRING`s on your device's screen.
+
+* ```sh
+  fbink [-WHf] [-k] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]
+  ```
+
+  Refresh the screen as per your specification, without touching the framebuffer.
+
+* ```sh
+  fbink [-WHf] --cls [top=NUM,left=NUM,width=NUM,height=NUM]
+  ```
+
+  Clear the screen (or a region of it).
+
+## Examples
+
+* ```sh
+  fbink -x 1 -y 10 "Hello World!"
+  ```
+
+  Prints 'Hello World!' on the eleventh line, starting at the second column from the left.
+
+* ```sh
+  fbink -pmh -y -5 "Hello World!"
+  ```
+
+  Prints 'Hello World!', highlighted (i.e., white on black with the default colors), centered & padded on both sides, on the fifth line starting from the bottom.
+
+* ```sh
+  fbink -pmM -y -8 "Hello World!"
+  ```
+
+  Prints 'Hello World!', centered & padded on both sides, eight lines above the center of the screen.
+
+## Options
+
+### Options affecting the message's position on screen
+
+* `-x NUM`, `--col NUM`
+
+  Begin printing `STRING` @ column `NUM` (Default: 0).
+
+  You might consider beginning at column 1 instead of 0, as column 0 (the leftmost one) may sometimes be slightly obscured by a bezel.
+
+  Use a negative value to count back from the right edge of the screen.
+
+* `-y NUM`, `--row NUM`
+
+  Begin printing `STRING` @ row `NUM` (Default: 0).
+
+  You might consider beginning at row 1 instead of 0, as row 0 (the topmost one) may sometimes be slightly obscured by a bezel, especially on Kobos.
+
+  Use a negative value to count back from the bottom of the screen.
+
+* `-X NUM`, `--hoffset NUM`
+
+  Adjust final text position by `NUM` pixels on the horizontal axis (Default: 0).
+
+  Honors negative values, and will let you push stuff off-screen, often without warning.
+
+* `-Y NUM`, `--voffset NUM`
+
+  Adjust final text position by `NUM` pixels on the vertical axis (Default: 0).
+
+  Honors negative values, and will let you push stuff off-screen, often without warning.
+
+* `-m`, `--centered`
+
+  Dynamically override col to print `STRING` at the center of the screen.
+
+  Special care is taken to avoid the very edges of the screen, to ensure the complete legibility of the message.
+
+* `-M`, `--halfway`
+
+  Dynamically adjust row to print `STRING` in the middle of the screen.
+
+  The value specified in row then becomes an offset, starting from the middle of the screen.
+
+* `-p`, `--padded`
+
+  Left pad `STRING` with blank spaces.
+
+  Most useful when combined with --centered to ensure a line will be completely filled, while still centering `STRING`, i.e., padding it on both sides.
+
+* `-r`, `--rpadded`
+
+  Right pad `STRING` with blank spaces.
+
+### Options affecting the message's appearance
+
+* `-h`, `--invert`
+
+  Print `STRING` in `BACKGROUND_COLOR` over `FOREGROUND_COLOR` instead of the reverse. (See `-B` and `-C`)
+
+* `-f`, ``--flash`
+
+  Ask the eInk driver to do a black flash when refreshing the area of the screen where `STRING` will be printed.
+
+  Note if compiled with `FBINK_FOR_KINDLE`: on legacy einkfb devices, this may not always be honored by the hardware.
+
+* `-c`, ``--clear`
+
+  Clear the full screen before printing.
+
+  Honors `-B`, ``--background`; `-h`, `--invert`; `-H`, `--nightmode`; `-W`, `--waveform`; `-D`, `--dither`; `-b`, `--norefresh`; `-w`, `--wait`
+
+  Can be specified on its own, without any `STRING`.
+
+  NOTE: If your intent is to simply clear the screen and *nothing else*, use `-k`, `--cls` instead!
+
+* `-W MODE`, `--waveform MODE` (not available if compiled with `FBINK_FOR_LINUX`)
+
+  Request a specific waveform update mode from the eInk controller, if supported (mainly useful for images).
+
+  Available waveform modes: `A2`, `DU`, `GL16`, `GC16` &amp; `AUTO`
+
+  Note if compiled with `FBINK_FOR_KINDLE`: as well as `REAGL`, `REAGLD`, `GC16_FAST`, `GL16_FAST`, `DU4`, `GL4`, `GL16_INV`, `GCK16` & `GLKW16` on some Kindles, depending on the model & FW version. Note that specifying a waveform mode is ignored on legacy einkfb devices, because the hardware doesn't expose such capabilities.
+
+  Note if compiled with `FBINK_FOR_POCKETBOOK`: as well as `GC4`, `A2IN`, `A2OUT`, `DU4`, `REAGL`, `REAGLD`, `GC16HQ` & `GS16`.
+
+  Note if compiled with `FBINK_FOR_KOBO` or `FBINK_FOR_CERVANTES`: as well as `GC4`, `REAGL` & `REAGLD`.
+
+  Note if not compiled with `FBINK_FOR_REMARKABLE`: Unsupported modes *should* safely downgrade to `AUTO`. Operative word being "should" ;). On some devices, `REAGL` & `REAGLD` expect to be flashing in order to behave properly.
+
+  Note if compiled with `FBINK_FOR_POCKETBOOK`: On devices with a B288 SoC, `AUTO` is *not* supported. FBInk will silently use `GC16` instead!
+
+* `-D`, `--dither` (not available if compiled with `FBINK_FOR_LINUX`)
+
+  Available dithering modes: `PASSTHROUGH`, `FLOYD_STEINBERG`, `ATKINSON`, `ORDERED`, `QUANT_ONLY` & `LEGACY`.
+
+  Note that this is only supported on recent devices, and that only a subset of these options may actually be supported by the HW (usually, `PASSTHROUGH` & `ORDERED`, check dmesg).
+
+  `LEGACY` may be supported on more devices, but what exactly it does in practice (and how well it works) depends on the exact device and/or FW version.
+
+  Note if compiled with `FBINK_FOR_KINDLE`: True (i.e., not `LEGACY`) hardware dithering is completely untested on Kindle, and, while the Oasis 2, PaperWhite 4 & Oasis 3 *should* support it, they *may* not, or at least not in the way FBInk expects...
+
+* `-H`, ``--nightmode` (not available if compiled with `FBINK_FOR_LINUX`)
+
+  Request full hardware inversion from the eInk controller, if supported.
+
+  Note that this can be used *in combination* with `-h`, `--invert`! One does not exclude the other, which may lead to some confusing behavior ;).
+
+  Note if compiled with `FBINK_FOR_KINDLE`: Note that requesting nightmode is ignored on legacy einkfb devices, because the hardware doesn't (easily) expose such capabilities.
+
+  Note that this may be ignored on some specific devices where it is known to be or have been unstable at some point.
+
+* `-b`, `--norefresh` (not available if compiled with `FBINK_FOR_LINUX`)
+
+  Only update the framebuffer, but don't actually refresh the eInk screen (useful when drawing in batch).
+
+* `-w`, `--wait` (not available if compiled with `FBINK_FOR_LINUX`)
+
+  Block until the kernel has finished processing the *last* update we sent, if any.
+
+  The actual delay depends for the most part on the waveform mode that was used.
+
+  See the API documentation around `fbink_wait_for_submission` & `fbink_wait_for_complete` for more details.
+
+  As a point of reference, eips only does a `wait_for_complete` after the flashing refresh of an image. We used to do that by default for *all* flashing updates until FBInk 1.20.0.
+
+* `-S`, `--size`
+
+  Override the automatic font scaling multiplier (Default: 0, automatic selection, ranging from 1 (no scaling), to 4 (4x upscaling), depending on screen resolution).
+
+  Note if compiled with `FBINK_WITH_FONTS`: Note that user-supplied values will be clamped to safe boundaries (from 1 to around 45 for most fonts, and from 1 to around 30 for `TALL`).
+
+  Note if not compiled with `FBINK_WITH_FONTS`: Note that user-supplied values will be clamped to safe boundaries (from 1 to around 45).
+
+  The exact upper value depends on the resolution of your screen.
+
+* `-F NAME`, `--font NAME`
+
+  Render glyphs from builtin font `NAME` (Default: IBM).
+
+  Note if compiled with `FBINK_WITH_FONTS`: Available font families: `IBM`, `UNSCII`, `ALT`, `THIN`, `FANTASY`, `MCR`, `TALL`, `BLOCK`, `LEGGIE`, `VEGGIE`, `KATES`, `FKP`, `CTRLD`, `ORP`, `ORPB`, `ORPI`, `SCIENTIFICA`, `SCIENTIFICAB`, `SCIENTIFICAI`, `TERMINUS`, `TERMINUSB`, `FATTY`, `SPLEEN`, `TEWI`, `TEWIB`, `TOPAZ`, `MICROKNIGHT`, `VGA`, `COZETTE`
+
+  Note if compiled with `FBINK_WITH_UNIFONT`: as well as `UNIFONT` & `UNIFONTDW`
+
+  NOTE: On low dpi, 600x800 devices, `ORP` or `TEWI`'s form factor may feel more familiar at default scaling.
+
+  Note if not compiled with `FBINK_WITH_FONTS`: Available font families: `IBM`
+
+  Note if compiled with `FBINK_WITH_OPENTYPE`: NOTE: If you're looking for vector font rendering, see the OpenType section a few lines down!
+
+* `-C NAME`, `--color NAME`
+
+  `-B NAME`, `--background NAME`
+
+  Color of the background the text will be printed on (Default: WHITE).
+
+  Color the text will be printed in (Default: BLACK).
+
+  Available colors: `BLACK`, `GRAY1`, `GRAY2`, `GRAY3`, `GRAY4`, `GRAY5`, `GRAY6`, `GRAY7`, `GRAY8`, `GRAY9`, `GRAYA`, `GRAYB`, `GRAYC`, `GRAYD`, `GRAYE`, `WHITE`.
+
+* `-o`, `--overlay`
+
+  Don't draw background pixels, and compute foreground pixel color based on the inverse of the underlying framebufer pixel.
+
+  Obviously ignores `-h`, `--invert` & `-C`, `--color` *as far as glyphs are concerned*. `-B`, `--background` is still honored if you combine this with `-c`, `--clear`.
+
+* `-O`, `--bgless`
+
+  Don't draw background pixels.
+
+  Obviously mutually exclusive with `-o`, `--overlay`, because it's simply a subset of what overlay does. If both are enabled, `-o`, `--overlay` takes precedence.
+
+* `-T`, `--fgless`
+
+  Don't draw foreground pixels.
+
+  Mutually exclusive with `-o`, `--overlay` or `-O`, `--bgless`, and takes precedence over them.
+
+### Options affecting the program's verbosity
+
+* `-v`, `--verbose`
+
+  Toggle printing diagnostic messages.
+
+* `-q`, `--quiet`
+
+  Toggle hiding hardware setup messages.
+
+* `-G`, `--syslog`
+
+  Send output to syslog instead of stdout & stderr.
+
+  Ought to be the first flag passed, otherwise, some commandline parsing errors might not honor it.
+
+### Options affecting the program's behavior
+
+* `-I`, `--interactive`
+
+  Enter a very basic interactive mode.
+
+* `-L`, `--linecountcode`
+
+  When successfully printing text, returns the total amount of printed lines as the process exit code.
+
+  NOTE: Will be inaccurate if there are more than 255 rows on screen!
+
+* `-l`, `--linecount`
+
+  When successfully printing text, outputs the total amount of printed lines in the final line of output to stdout (NOTE: enforces quiet & non-verbose!).
+
+  NOTE: With OT/TTF rendering, will output a top margin value to use as-is instead (or 0 if there's no space left on screen)! The OT/TTF codepath also returns more data, including the results of the line-breaking computations, so it's in an eval-friendly format instead.
+
+* `-E`, `--coordinates`
+
+  When printing something, outputs the coordinates & dimensions of what was printed to stdout, in a format easily consumable by eval (NOTE: enforces quiet & non-verbose!).
+
+  NOTE: For both `-l`, `--linecount` & `-E`, `--coordinates`, output will only be sent to stdout on *success*. On error, the usual error message is sent to stderr.
+
+  Given that, you may want to store stdout only in a variable and check the return code for success before running eval on that var!
+
+* `-P NUM`, `--progressbar NUM`
+
+  Draw a `NUM` full progress bar (full-width).
+
+  Like other alternative modes, does *NOT* have precedence over text printing.
+
+  Ignores `-o`, `--overlay`; `-x`, `--col`; `-X`, `--hoffset`; as well as `-m`, `--centered` & `-p`, `--padded`.
+
+* `-A NUM`, `--activitybar NUM`
+
+  Draw an activity bar on step `NUM` (full-width). `NUM` must be between 0 and 16. Like other alternative modes, does *NOT* have precedence over text printing.
+
+  NOTE: If `NUM` is negative, will cycle between each possible value every 750ms, until the death of the sun! Be careful not to be caught in an involuntary infinite loop!
+
+  Ignores `-x`, `--col`; `-X`, `--hoffset`; as well as `-m`, `--centered` & `-p`, `--padded`.
+
+* `-V`, `--noviewport`
+
+  Ignore any & all viewport corrections, be it from Kobo devices with rows of pixels hidden by a bezel, or a dynamic offset applied to rows when vertical fit isn't perfect.
+
+### Option for only clearing & refreshing screen
+
+* `-s [top=NUM,left=NUM,width=NUM,height=NUM]` , `--refresh [top=NUM,left=NUM,width=NUM,height=NUM]`
+
+  Eschew printing a STRING, and simply refresh the screen as per your specification, without touching the framebuffer.
+
+  Honors `-W`, `--waveform`; `-H`, `--nightmode` & `-f`, `--flash`.
+
+  The specified rectangle *must* completely fit on screen, or the ioctl will fail. 
+
+  Note if compiled with `FBINK_FOR_KOBO` or `FBINK_FOR_CERVANTES`: the arguments are passed as-is to the ioctl, no viewport or rotation quirks are applied!
+
+  If you just want a full-screen refresh (which will honor `-f`, `--flash`), don't pass any suboptions, e.g., `fbink -s` (if you group short options together, it needs to be the last in its group, i.e., `-fs` and not `-sf`).
+
+  Specifying one or more `STRING` takes precedence over this mode.
+
+  Example:
+
+  * ```sh
+    fbink -s top=20,left=10,width=500,height=600 -W GC16 -D ORDERED
+    ```
+
+    Refreshes a 500x600 rectangle with its top-left corner at coordinates (10, 20) with a GC16 waveform mode and `ORDERED` hardware dithering.
+
+* `-k [top=NUM,left=NUM,width=NUM,height=NUM]`, `--cls [top=NUM,left=NUM,width=NUM,height=NUM]` 
+
+  Clear the screen (or a region of it), and abort early.
+
+  Honors `-B`, ``--background`; `-h`, `--invert`; `-H`, `--nightmode`; `-W`, `--waveform`; `-D`, `--dither`; `-b`, `--norefresh`; `-w`, `--wait`
+
+  This takes precedence over *everything* and will abort as soon as it's done.
+
+  If you just want a full-screen clear (which will honor `-f`, `--flash`), don't pass any suboptions,
+
+  e.g., `fbink -k` (if you group short options together, it needs to be the last in its group, i.e., `-fk` and not `-kf`).
+
+### Option for OpenType & TrueType font support (if compiled with `FBINK_WITH_OPENTYPE`)
+
+* `-t`, `--truetype regular=FILE,bold=FILE,italic=FILE,bolditalic=FILE,size=NUM,px=NUM,top=NUM,bottom=NUM,left=NUM,right=NUM,padding=PAD,style=STYLE,format,notrunc,compute`
+
+  - `regular`, `bold`, `italic` & `bolditalic` should point to the font file matching their respective font style. At least one of them MUST be specified.
+
+  - `size` sets the rendering size, in points. Defaults to 12pt if unset. Can be a decimal value.
+
+  - `px` sets the rendering size, in pixels. Optional. Takes precedence over size if specified.
+
+  - `top`, `bottom`, `left` & `right` set the margins used to define the display area. Defaults to 0, i.e., the full screen, starting at the top-left corner.
+
+    NOTE: If a negative value is supplied, counts backward from the opposite edge. Mostly useful with top & left to position stuff relative to the bottom right corner.
+
+  - `padding` can optionally be set to ensure the drawing area on both sides of the printed content is padded with the background color on one or both axis.
+
+    Available padding axis: `HORIZONTAL`, `VERTICAL`, or `BOTH` (Defaults to `NONE`). Useful to avoid overlaps on consecutive prints at the same coordinates.
+
+  - If style is specified, it dictates the default font style to use (e.g., `REGULAR`, `BOLD`, `ITALIC` or `BOLD_ITALIC`). Defaults to `REGULAR`.
+
+  - If `format` is specified, instead of the default style, the underscore/star Markdown syntax will be honored to set the font style (i.e., `*italic*`, `**bold**` & `***bold italic***`).
+
+  - If `notrunc` is specified, truncation will be considered a failure.
+
+    NOTE: This may not prevent drawing/refreshing the screen if the truncation couldn't be predicted at compute time!
+
+    On the CLI, this will prevent you from making use of the returned computation info, as this will chain a CLI abort.
+
+  - If `compute` is specified, no rendering will be done, and only the line-breaking computation pass will run. You'll generally want to use that combined with `-l`, `--linecount`.
+
+  Honors `-h`, `--invert`; `-f`, `--flash`; `-c`, `--clear`; `-W`, `--waveform`; `-D`, `--dither`; `-H`, `--nightmode`; `-b`, `--norefresh`; `-m`, `--centered`; `-M`, `--halfway`; `-o`, `--overlay`; `-T`, `--fgless`; `-O`, `--bgless`; `-C`, `--color`; `-B`, `--background`; `-l`, `--linecount`.
+
+  Examples:
+
+  * If compiled with `FBINK_FOR_KINDLE`:
+
+    ```sh
+    fbink -t regular=/usr/java/lib/fonts/Caecilia_LT_65_Medium.ttf,bold=/usr/java/lib/fonts/Caecilia_LT_75_Bold.ttf,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
+    ```
+
+    Will use Caecilia to print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
+
+  * If not compiled with `FBINK_FOR_KINDLE`:
+
+    ```sh
+    fbink -t regular=/mnt/onboard/fonts/NotoSans-Regular.ttf,bold=/mnt/onboard/fonts/NotoSans-Bold.ttf,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
+    ```
+
+    Will use NotoSans to print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
+
+  * Note if compiled with `FBINK_FOR_KOBO`: this means you will NOT be able to use system fonts on Kobo, because they're all obfuscated.
+
+## Notes about multiple string arguments
+
+You can specify multiple `STRING`s in a single invocation of `fbink`, each consecutive one will be printed on the subsequent line.
+
+Although it's worth mentioning that this will lead to undesirable results when combined with `--clear`, because the screen is cleared before each `STRING`, meaning you'll only get to see the final one.
+
+If you want to properly print a long string, better do it in a single argument, FBInk will do its best to spread it over multiple lines sanely. It will also honor the linefeed character (and I do mean the actual control character, not the human-readable escape sequence), which comes in handy when passing a few lines of logs straight from tail as an argument.
+
+
+---
+
+/// TODO: add image notes /// blocker https://github.com/NiLuJe/FBInk/issues/58
+
+/// remaining parts https://github.com/NiLuJe/FBInk/blob/master/fbink_cmd.c#L281-L356
+

--- a/API.md
+++ b/API.md
@@ -110,7 +110,7 @@
 
   Ask the eInk driver to do a black flash when refreshing the area of the screen where `STRING` will be printed.
 
-  Note if compiled with `FBINK_FOR_KINDLE`: on legacy einkfb devices, this may not always be honored by the hardware.
+  Note for Kindle: on legacy einkfb devices, this may not always be honored by the hardware.
 
 * `-c`, `--clear`
 
@@ -122,23 +122,23 @@
 
   NOTE: If your intent is to simply clear the screen and *nothing else*, use `-k`, `--cls` instead!
 
-* `-W`, `--waveform` `MODE` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-W`, `--waveform` `MODE` (only available for e-Ink devices)
 
   Request a specific waveform update mode from the eInk controller, if supported (mainly useful for images).
 
   Available waveform modes: `A2`, `DU`, `GL16`, `GC16` &amp; `AUTO`
 
-  Note if compiled with `FBINK_FOR_KINDLE`: as well as `REAGL`, `REAGLD`, `GC16_FAST`, `GL16_FAST`, `DU4`, `GL4`, `GL16_INV`, `GCK16` & `GLKW16` on some Kindles, depending on the model & FW version. Note that specifying a waveform mode is ignored on legacy einkfb devices, because the hardware doesn't expose such capabilities.
+  Note for Kobo and Cervantes: as well as `GC4`, `REAGL` & `REAGLD`.
 
-  Note if compiled with `FBINK_FOR_POCKETBOOK`: as well as `GC4`, `A2IN`, `A2OUT`, `DU4`, `REAGL`, `REAGLD`, `GC16HQ` & `GS16`.
+  Note for Kindle: as well as `REAGL`, `REAGLD`, `GC16_FAST`, `GL16_FAST`, `DU4`, `GL4`, `GL16_INV`, `GCK16` & `GLKW16` on some Kindles, depending on the model & FW version. Note that specifying a waveform mode is ignored on legacy einkfb devices, because the hardware doesn't expose such capabilities.
 
-  Note if compiled with `FBINK_FOR_KOBO` or `FBINK_FOR_CERVANTES`: as well as `GC4`, `REAGL` & `REAGLD`.
+  Note for PocketBook: as well as `GC4`, `A2IN`, `A2OUT`, `DU4`, `REAGL`, `REAGLD`, `GC16HQ` & `GS16`.
 
-  Note if not compiled with `FBINK_FOR_REMARKABLE`: Unsupported modes *should* safely downgrade to `AUTO`. Operative word being "should" ;). On some devices, `REAGL` & `REAGLD` expect to be flashing in order to behave properly.
+  Note for all other than reMarkable: Unsupported modes *should* safely downgrade to `AUTO`. Operative word being "should" ;). On some devices, `REAGL` & `REAGLD` expect to be flashing in order to behave properly.
 
-  Note if compiled with `FBINK_FOR_POCKETBOOK`: On devices with a B288 SoC, `AUTO` is *not* supported. FBInk will silently use `GC16` instead!
+  Note for PocketBook: On devices with a B288 SoC, `AUTO` is *not* supported. FBInk will silently use `GC16` instead!
 
-* `-D`, `--dither` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-D`, `--dither` (only available for e-Ink devices)
 
   Available dithering modes: `PASSTHROUGH`, `FLOYD_STEINBERG`, `ATKINSON`, `ORDERED`, `QUANT_ONLY` & `LEGACY`.
 
@@ -146,23 +146,23 @@
 
   `LEGACY` may be supported on more devices, but what exactly it does in practice (and how well it works) depends on the exact device and/or FW version.
 
-  Note if compiled with `FBINK_FOR_KINDLE`: True (i.e., not `LEGACY`) hardware dithering is completely untested on Kindle, and, while the Oasis 2, PaperWhite 4 & Oasis 3 *should* support it, they *may* not, or at least not in the way FBInk expects...
+  Note for Kindle: True (i.e., not `LEGACY`) hardware dithering is completely untested on Kindle, and, while the Oasis 2, PaperWhite 4 & Oasis 3 *should* support it, they *may* not, or at least not in the way FBInk expects...
 
-* `-H`, `--nightmode` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-H`, `--nightmode` (only available for e-Ink devices)
 
   Request full hardware inversion from the eInk controller, if supported.
 
   Note that this can be used *in combination* with `-h`, `--invert`! One does not exclude the other, which may lead to some confusing behavior ;).
 
-  Note if compiled with `FBINK_FOR_KINDLE`: Note that requesting nightmode is ignored on legacy einkfb devices, because the hardware doesn't (easily) expose such capabilities.
+  Note for Kindle: Note that requesting nightmode is ignored on legacy einkfb devices, because the hardware doesn't (easily) expose such capabilities.
 
   Note that this may be ignored on some specific devices where it is known to be or have been unstable at some point.
 
-* `-b`, `--norefresh` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-b`, `--norefresh` (only available for e-Ink devices)
 
   Only update the framebuffer, but don't actually refresh the eInk screen (useful when drawing in batch).
 
-* `-w`, `--wait` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-w`, `--wait` (only available for e-Ink devices)
 
   Block until the kernel has finished processing the *last* update we sent, if any.
 
@@ -296,7 +296,7 @@
 
   The specified rectangle *must* completely fit on screen, or the ioctl will fail. 
 
-  Note if compiled with `FBINK_FOR_KOBO` or `FBINK_FOR_CERVANTES`: the arguments are passed as-is to the ioctl, no viewport or rotation quirks are applied!
+  Note for Kobo and Cervantes: the arguments are passed as-is to the ioctl, no viewport or rotation quirks are applied!
 
   If you just want a full-screen refresh (which will honor `-f`, `--flash`), don't pass any suboptions, e.g., `fbink -s` (if you group short options together, it needs to be the last in its group, i.e., `-fs` and not `-sf`).
 
@@ -356,7 +356,7 @@
 
   Examples:
 
-  * If compiled with `FBINK_FOR_KINDLE`:
+  * For Kindle:
 
     ```sh
     fbink -t regular=/usr/java/lib/fonts/Caecilia_LT_65_Medium.ttf,bold=/usr/java/lib/fonts/Caecilia_LT_75_Bold.ttf,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
@@ -364,7 +364,7 @@
 
     Will use Caecilia to print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
 
-  * If not compiled with `FBINK_FOR_KINDLE`:
+  * For other than Kindle:
 
     ```sh
     fbink -t regular=/mnt/onboard/fonts/NotoSans-Regular.ttf,bold=/mnt/onboard/fonts/NotoSans-Bold.ttf,size=24,top=100,bottom=500,left=25,right=50,format "Hello **world**!"
@@ -372,7 +372,7 @@
 
     Will use NotoSans to print "Hello world!" at 24pt in a display area starting from 100px down the top of the screen to 500px before the bottom of the screen, from 25px of the left edge of the screen until 50px before the right edge. Honoring the Markdown syntax, "Hello" will be printed with the Regular font style, while "world" will use the Bold font style. You will NOT be able to use obfuscated or encrypted fonts.
 
-  * Note if compiled with `FBINK_FOR_KOBO`: this means you will NOT be able to use system fonts on Kobo, because they're all obfuscated.
+  * Note for Kobo: this means you will NOT be able to use system fonts on Kobo, because they're all obfuscated.
 
 ### Options for printing an image (if compiled with `FBINK_WITH_IMAGE`)
 
@@ -445,12 +445,6 @@ Notes:
 * In some cases, exotic encoding settings may not be supported.
 * Transparency is supported, but it may be slightly slower (because we may need to do alpha blending).
   * You can use the `-a`, `--flatten` flag to avoid the potential performance penalty by always ignoring alpha.
-
-
-
-
-
-
 
 ## Notes about multiple string arguments
 

--- a/API.md
+++ b/API.md
@@ -60,7 +60,7 @@
 
   Use a negative value to count back from the bottom of the screen.
 
-* `-`, `--hoffset` `NUM`
+* `-X`, `--hoffset` `NUM`
 
   Adjust final text position by `NUM` pixels on the horizontal axis (Default: 0).
 
@@ -189,7 +189,7 @@
   Note if not compiled with `FBINK_WITH_FONTS`: Available font families: `IBM`
 
   Note if compiled with `FBINK_WITH_OPENTYPE`: NOTE: If you're looking for vector font rendering, see the OpenType section a few lines down!
-  
+
 * `-C`, `--color` `NAME`
 
   `-B`, `--background` `NAME`
@@ -227,7 +227,7 @@
 * `-q`, `--quiet`
 
   Toggle hiding hardware setup messages.
-  
+
 * `-G`, `--syslog`
 
   Send output to syslog instead of stdout & stderr.
@@ -375,8 +375,6 @@ You can specify multiple `STRING`s in a single invocation of `fbink`, each conse
 Although it's worth mentioning that this will lead to undesirable results when combined with `--clear`, because the screen is cleared before each `STRING`, meaning you'll only get to see the final one.
 
 If you want to properly print a long string, better do it in a single argument, FBInk will do its best to spread it over multiple lines sanely. It will also honor the linefeed character (and I do mean the actual control character, not the human-readable escape sequence), which comes in handy when passing a few lines of logs straight from tail as an argument.
-
-
 
 
 

--- a/API.md
+++ b/API.md
@@ -18,7 +18,7 @@
   fbink [-WHf] [-k] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]
   ```
 
-  Refresh the screen as per your specification, without touching the framebuffer.
+  Refresh the screen (or a region of it).
 
 * ```sh
   fbink [-BhHWDbw] --cls [top=NUM,left=NUM,width=NUM,height=NUM]

--- a/API.md
+++ b/API.md
@@ -15,10 +15,10 @@
   Print image on your device's screen. // TODO: verify allowed flags in this usage scenario
 
 * ```sh
-  fbink [-WHf XXXXX] [-k] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]
+  fbink [-WHf] [-k] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]
   ```
 
-  Refresh the screen as per your specification, without touching the framebuffer. // TODO, exhaustively list options that are compatible with `--refresh`.
+  Refresh the screen as per your specification, without touching the framebuffer.
 
 * ```sh
   fbink [-WHf XXXXX] --cls [top=NUM,left=NUM,width=NUM,height=NUM]

--- a/API.md
+++ b/API.md
@@ -100,17 +100,17 @@
 
   Print `STRING` in `BACKGROUND_COLOR` over `FOREGROUND_COLOR` instead of the reverse. (See `-B` and `-C`)
 
-* `-f`, ``--flash`
+* `-f`, `--flash`
 
   Ask the eInk driver to do a black flash when refreshing the area of the screen where `STRING` will be printed.
 
   Note if compiled with `FBINK_FOR_KINDLE`: on legacy einkfb devices, this may not always be honored by the hardware.
 
-* `-c`, ``--clear`
+* `-c`, `--clear`
 
   Clear the full screen before printing.
 
-  Honors `-B`, ``--background`; `-h`, `--invert`; `-H`, `--nightmode`; `-W`, `--waveform`; `-D`, `--dither`; `-b`, `--norefresh`; `-w`, `--wait`
+  Honors `-B`, `--background`; `-h`, `--invert`; `-H`, `--nightmode`; `-W`, `--waveform`; `-D`, `--dither`; `-b`, `--norefresh`; `-w`, `--wait`
 
   Can be specified on its own, without any `STRING`.
 
@@ -142,7 +142,7 @@
 
   Note if compiled with `FBINK_FOR_KINDLE`: True (i.e., not `LEGACY`) hardware dithering is completely untested on Kindle, and, while the Oasis 2, PaperWhite 4 & Oasis 3 *should* support it, they *may* not, or at least not in the way FBInk expects...
 
-* `-H`, ``--nightmode` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-H`, `--nightmode` (not available if compiled with `FBINK_FOR_LINUX`)
 
   Request full hardware inversion from the eInk controller, if supported.
 
@@ -308,7 +308,7 @@
 
   Clear the screen (or a region of it), and abort early.
 
-  Honors `-B`, ``--background`; `-h`, `--invert`; `-H`, `--nightmode`; `-W`, `--waveform`; `-D`, `--dither`; `-b`, `--norefresh`; `-w`, `--wait`
+  Honors `-B`, `--background`; `-h`, `--invert`; `-H`, `--nightmode`; `-W`, `--waveform`; `-D`, `--dither`; `-b`, `--norefresh`; `-w`, `--wait`
 
   This takes precedence over *everything* and will abort as soon as it's done.
 
@@ -375,6 +375,8 @@ You can specify multiple `STRING`s in a single invocation of `fbink`, each conse
 Although it's worth mentioning that this will lead to undesirable results when combined with `--clear`, because the screen is cleared before each `STRING`, meaning you'll only get to see the final one.
 
 If you want to properly print a long string, better do it in a single argument, FBInk will do its best to spread it over multiple lines sanely. It will also honor the linefeed character (and I do mean the actual control character, not the human-readable escape sequence), which comes in handy when passing a few lines of logs straight from tail as an argument.
+
+
 
 
 ---

--- a/API.md
+++ b/API.md
@@ -21,10 +21,10 @@
   Refresh the screen as per your specification, without touching the framebuffer.
 
 * ```sh
-  fbink [-WHf XXXXX] --cls [top=NUM,left=NUM,width=NUM,height=NUM]
+  fbink [-BhHWDbw] --cls [top=NUM,left=NUM,width=NUM,height=NUM]
   ```
 
-  Clear the screen (or a region of it). // TODO, exhaustively list options that are compatible with `--refresh`.
+  Clear the screen (or a region of it).
 
 ## Examples
 

--- a/API.md
+++ b/API.md
@@ -44,7 +44,7 @@
 
 ### Options affecting the message's position on screen
 
-* `-x NUM`, `--col NUM`
+* `-x`, `--col` `NUM`
 
   Begin printing `STRING` @ column `NUM` (Default: 0).
 
@@ -52,7 +52,7 @@
 
   Use a negative value to count back from the right edge of the screen.
 
-* `-y NUM`, `--row NUM`
+* `-y`, `--row` `NUM`
 
   Begin printing `STRING` @ row `NUM` (Default: 0).
 
@@ -60,13 +60,13 @@
 
   Use a negative value to count back from the bottom of the screen.
 
-* `-X NUM`, `--hoffset NUM`
+* `-`, `--hoffset` `NUM`
 
   Adjust final text position by `NUM` pixels on the horizontal axis (Default: 0).
 
   Honors negative values, and will let you push stuff off-screen, often without warning.
 
-* `-Y NUM`, `--voffset NUM`
+* `-Y`, `--voffset` `NUM`
 
   Adjust final text position by `NUM` pixels on the vertical axis (Default: 0).
 
@@ -116,7 +116,7 @@
 
   NOTE: If your intent is to simply clear the screen and *nothing else*, use `-k`, `--cls` instead!
 
-* `-W MODE`, `--waveform MODE` (not available if compiled with `FBINK_FOR_LINUX`)
+* `-W`, `--waveform` `MODE` (not available if compiled with `FBINK_FOR_LINUX`)
 
   Request a specific waveform update mode from the eInk controller, if supported (mainly useful for images).
 
@@ -176,7 +176,7 @@
 
   The exact upper value depends on the resolution of your screen.
 
-* `-F NAME`, `--font NAME`
+* `-F`, `--font` `NAME`
 
   Render glyphs from builtin font `NAME` (Default: IBM).
 
@@ -189,10 +189,10 @@
   Note if not compiled with `FBINK_WITH_FONTS`: Available font families: `IBM`
 
   Note if compiled with `FBINK_WITH_OPENTYPE`: NOTE: If you're looking for vector font rendering, see the OpenType section a few lines down!
+  
+* `-C`, `--color` `NAME`
 
-* `-C NAME`, `--color NAME`
-
-  `-B NAME`, `--background NAME`
+  `-B`, `--background` `NAME`
 
   Color of the background the text will be printed on (Default: WHITE).
 
@@ -227,7 +227,7 @@
 * `-q`, `--quiet`
 
   Toggle hiding hardware setup messages.
-
+  
 * `-G`, `--syslog`
 
   Send output to syslog instead of stdout & stderr.
@@ -260,7 +260,7 @@
 
   Given that, you may want to store stdout only in a variable and check the return code for success before running eval on that var!
 
-* `-P NUM`, `--progressbar NUM`
+* `-P`, `--progressbar` `NUM`
 
   Draw a `NUM` full progress bar (full-width).
 
@@ -268,7 +268,7 @@
 
   Ignores `-o`, `--overlay`; `-x`, `--col`; `-X`, `--hoffset`; as well as `-m`, `--centered` & `-p`, `--padded`.
 
-* `-A NUM`, `--activitybar NUM`
+* `-A`, `--activitybar` `NUM`
 
   Draw an activity bar on step `NUM` (full-width). `NUM` must be between 0 and 16. Like other alternative modes, does *NOT* have precedence over text printing.
 
@@ -282,7 +282,7 @@
 
 ### Option for only clearing & refreshing screen
 
-* `-s [top=NUM,left=NUM,width=NUM,height=NUM]` , `--refresh [top=NUM,left=NUM,width=NUM,height=NUM]`
+* `-s` , `--refresh` `[top=NUM,left=NUM,width=NUM,height=NUM]`
 
   Eschew printing a STRING, and simply refresh the screen as per your specification, without touching the framebuffer.
 
@@ -304,7 +304,7 @@
 
     Refreshes a 500x600 rectangle with its top-left corner at coordinates (10, 20) with a GC16 waveform mode and `ORDERED` hardware dithering.
 
-* `-k [top=NUM,left=NUM,width=NUM,height=NUM]`, `--cls [top=NUM,left=NUM,width=NUM,height=NUM]` 
+* `-k`, `--cls` `[top=NUM,left=NUM,width=NUM,height=NUM]` 
 
   Clear the screen (or a region of it), and abort early.
 
@@ -318,7 +318,7 @@
 
 ### Option for OpenType & TrueType font support (if compiled with `FBINK_WITH_OPENTYPE`)
 
-* `-t`, `--truetype regular=FILE,bold=FILE,italic=FILE,bolditalic=FILE,size=NUM,px=NUM,top=NUM,bottom=NUM,left=NUM,right=NUM,padding=PAD,style=STYLE,format,notrunc,compute`
+* `-t`, `--truetype` `regular=FILE,bold=FILE,italic=FILE,bolditalic=FILE,size=NUM,px=NUM,top=NUM,bottom=NUM,left=NUM,right=NUM,padding=PAD,style=STYLE,format,notrunc,compute`
 
   - `regular`, `bold`, `italic` & `bolditalic` should point to the font file matching their respective font style. At least one of them MUST be specified.
 
@@ -375,6 +375,7 @@ You can specify multiple `STRING`s in a single invocation of `fbink`, each conse
 Although it's worth mentioning that this will lead to undesirable results when combined with `--clear`, because the screen is cleared before each `STRING`, meaning you'll only get to see the final one.
 
 If you want to properly print a long string, better do it in a single argument, FBInk will do its best to spread it over multiple lines sanely. It will also honor the linefeed character (and I do mean the actual control character, not the human-readable escape sequence), which comes in handy when passing a few lines of logs straight from tail as an argument.
+
 
 
 

--- a/API.md
+++ b/API.md
@@ -12,7 +12,7 @@
   fbink [-fcWDHbhxyS] --image file=PATH,x=NUM,y=NUM,halign=ALIGN,valign=ALIGN,w=NUM,h=NUM,dither [--img PATH]
   ```
 
-  Print image on your device's screen. // TODO: verify allowed flags in this usage scenario
+  Print image on your device's screen.
 
 * ```sh
   fbink [-WHf] [-k] --refresh [top=NUM,left=NUM,width=NUM,height=NUM]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ See also the various bindings in other languages, which often include a few exam
 
 ## How can I tinker with it?
 
-A CLI utility is available, built around the same public API that can be used via a shared or static library for C projects, or via FFI in other languages (beware, though, it's licensed under the GPLv3+, not the LGPL).  
-The gist of the documentation is composed of the various comments in the [public header](fbink.h), detailing how the API can be used, and what for. Don't hesitate to contact me if things appear unclear!  
-You can also launch the `fbink` CLI tool itself with no argument (or the `-Q, --help` flag) for a giant wall of text describing its capabilities. You can also take a peek at it directly in [the main CLI source file](https://github.com/NiLuJe/FBInk/blob/master/fbink_cmd.c), it's the first function declared there.
+A CLI utility is available, built around the same public API that can be used via a shared or static library for C projects, or via FFI in other languages (beware, though, it's licensed under the GPLv3+, not the LGPL).
+For the CLI utility, see the [API documentation](API.md) or run `fbink --help` for details.
+For the library, see the [public header](fbink.h). Don't hesitate to contact me if things appear unclear!  
 
 NOTE: It generally makes *NO* attempt at handling software rotation, because that currently appears to be the right thing to do with both current Kobo FW versions and on Kindle.  
 YMMV on older FW, or if something else is fudging with fb rotation, or if your application is implementing rotation in software (i.e., a rotated viewport).  


### PR DESCRIPTION
# Live preview

https://github.com/fulldecent/FBInk/blob/patch-7/API.md

# Work plan:

- [x] Translate all command documentation from [C code](https://github.com/NiLuJe/FBInk/blob/master/fbink_cmd.c) to Markdown
  - Progress: everything is touched except the IMAGE section and below (i.e. https://github.com/NiLuJe/FBInk/blob/master/fbink_cmd.c#L281-L356)
- [x] Address every XXX and TODO on the page
- [ ] Consider if some options should be extracted from the "Options affecting the message's position on screen", "Options affecting the message's appearance" where they also apply to images into a more general section name.
- [ ] The synopses uses a code block inside a list. GitHub renders this poorly and/or incorrectly. Decide if something needs to be done about that.
- [ ] Reconcile differences between this new doc and existing documentation (help requested)

---

# Differences:

I have taken liberty in the interest of readability of reorganizing slightly the documentation. Every change, other than minor formatting is listed below. I recommend that these all be adopted as updates to the printf version (help requested with that).

- [ ] Additional synopses added. Certain useful modes don't use STRING, those are separated out into separate synopses lines.
- [ ] `--refresh` and `--cls` were moved to be adjacent and added under a title "Option for only clearing & refreshing screen".
- [ ] Moved OpenType & TrueType notes in as a new section under options.
- [ ] Moved Notes about multiple string arguments to after the options.

Every other bite-sized difference was submitted as a separate PR already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/niluje/fbink/59)
<!-- Reviewable:end -->
