### PR TITLE
Add more functionality to the API

### DIFF
--- a/fbink.c
+++ b/fbink.c
@@ -4698,7 +4698,8 @@ void
 		fbink_state->view_height   = viewHeight;
 		fbink_state->screen_width  = screenWidth;
 		fbink_state->screen_height = screenHeight;
-		fbink_state->bpp           = vInfo.bits_per_pixel;
+        fbink_state->screen_stride = fInfo.line_length;
+        fbink_state->bpp           = vInfo.bits_per_pixel;
 		strncpy(fbink_state->device_name, deviceQuirks.deviceName, sizeof(fbink_state->device_name) - 1U);
 		strncpy(
 		    fbink_state->device_codename, deviceQuirks.deviceCodename, sizeof(fbink_state->device_codename) - 1U);
@@ -4725,7 +4726,8 @@ void
 		fbink_state->ntx_boot_rota           = deviceQuirks.ntxBootRota;
 		fbink_state->ntx_rota_quirk          = deviceQuirks.ntxRotaQuirk;
 		fbink_state->is_ntx_quirky_landscape = deviceQuirks.isNTX16bLandscape;
-		fbink_state->current_rota            = (uint8_t) vInfo.rotate;
+        fbink_state->current_rota_native     = (uint8_t) vInfo.rotate;
+        fbink_state->current_rota_canonical  = fbink_rota_native_to_canonical(vInfo.rotate);
 		fbink_state->can_rotate              = deviceQuirks.canRotate;
 		fbink_state->can_hw_invert           = deviceQuirks.canHWInvert;
 	} else {

--- a/fbink.c
+++ b/fbink.c
@@ -4789,8 +4789,7 @@ void
 		fbink_state->ntx_boot_rota           = deviceQuirks.ntxBootRota;
 		fbink_state->ntx_rota_quirk          = deviceQuirks.ntxRotaQuirk;
 		fbink_state->is_ntx_quirky_landscape = deviceQuirks.isNTX16bLandscape;
-        fbink_state->current_rota_native     = (uint8_t) vInfo.rotate;
-        fbink_state->current_rota_canonical  = fbink_rota_native_to_canonical(vInfo.rotate);
+        fbink_state->current_rota            = (uint8_t) vInfo.rotate;
 		fbink_state->can_rotate              = deviceQuirks.canRotate;
 		fbink_state->can_hw_invert           = deviceQuirks.canHWInvert;
 	} else {

--- a/fbink.c
+++ b/fbink.c
@@ -10826,6 +10826,25 @@ FBInkRect
 	return lastRect;
 }
 
+
+// Grants direct access to the frame buffer pointer as well as the size of the frame buffer allocation
+int
+    fbink_get_fb_pointer(int fbfd, FBPtrInfo* fbInfo)
+{
+    if (!isFbMapped)
+    {
+        if (memmap_fb(fbfd) != EXIT_SUCCESS) {
+            return ERRCODE(EXIT_FAILURE);
+        }
+    }
+
+    fbInfo->fbPtr = fbPtr;
+    fbInfo->allocationSize = deviceQuirks.isSunxi? sunxiCtx.alloc_size : fInfo.smem_len;
+
+    return EXIT_SUCCESS;
+}
+
+
 // And now, we just bundle auxiliary parts of the public or private API,
 // that are implemented in separate source files because they deal with a specific concept,
 // but that still rely heavily on either the public or the private API.

--- a/fbink.h
+++ b/fbink.h
@@ -480,6 +480,14 @@ typedef struct
 	bool      is_full;
 } FBInkDump;
 
+// For fbink_get_fb_pointer
+typedef struct
+{
+    unsigned char *fbPtr;
+    unsigned long allocationSize;
+
+} FBPtrInfo;
+
 //
 ////
 //
@@ -1150,6 +1158,13 @@ FBINK_API int fbink_sunxi_ntx_enforce_rota(int                      fbfd,
 					   SUNXI_FORCE_ROTA_INDEX_T mode,
 					   const FBInkConfig* restrict fbink_cfg);
 
+
+// Grants direct access to the frame buffer pointer as well as the size of the frame buffer allocation.
+// If the framebuffer is not yet allocated it will do so and return the result of the operation.
+FBINK_API int
+    fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
+
+
 //
 ///
 //
@@ -1166,6 +1181,7 @@ FBINK_API int fbink_sunxi_ntx_enforce_rota(int                      fbfd,
 //
 // See fbink_cmd.c for an example of the former, and KFMon for an example of the latter.
 // NOTE: Although fairly stupid in practice, utils/dump.c is less convoluted than fbink_cmd.c, making it worth a look...
+
 
 #ifdef __cplusplus
 }

--- a/fbink.h
+++ b/fbink.h
@@ -1265,10 +1265,11 @@ FBINK_API int
     fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
 
 
-// Sets the framebuffer bits per pixel and rotation and inwoke a reinit afterwards
+// Sets the framebuffer bits per pixel and rotation and invoke a reinit afterwards
+// rota will be the rotation in natve format; use fbink_rota_canonical_to_native to convert it to canonical
 // bpp will remain unchanged if the value is < 8
 // req_gray will remain unchanged if the value is < 0
-// on sunxi devices it will inwoke fbink_sunxi_ntx_enforce_rota
+// on sunxi devices it will invoke fbink_sunxi_ntx_enforce_rota
 FBINK_API int
     fbink_set_fb_info(int fbFd, int32_t bpp, int8_t rota, int32_t req_gray,
                const FBInkConfig* restrict fbink_cfg);

--- a/fbink.h
+++ b/fbink.h
@@ -1156,7 +1156,7 @@ FBINK_API int fbink_toggle_sunxi_ntx_pen_mode(int fbfd, bool toggle);
 // NOTE: See the comments in the SUNXI_FORCE_ROTA_INDEX_E enum.
 //       In particular, the fact that the most interesting modes aren't actually supported because of technical limitations...
 // NOTE: On success, this will reinit the state *now* (returning the exact same values as fbink_reinit).
-FBINK_API int fbink_sunxi_ntx_enforce_rota(int                      fbfd,
+FBINK_API int fbink_sunxi_ntx_enforce_rota(int fbfd,
 					   SUNXI_FORCE_ROTA_INDEX_T mode,
 					   const FBInkConfig* restrict fbink_cfg);
 
@@ -1165,6 +1165,22 @@ FBINK_API int fbink_sunxi_ntx_enforce_rota(int                      fbfd,
 // If the framebuffer is not yet allocated it will do so and return the result of the operation.
 FBINK_API int
     fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
+
+
+// Grants direct access to the frame buffer pointer as well as the size of the frame buffer allocation.
+// If the framebuffer is not yet allocated it will do so and return the result of the operation.
+FBINK_API int
+    fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
+
+
+// Sets the framebuffer bits per pixel and rotation and inwoke a reinit afterwards
+// bpp will remain unchanged if the value is < 8
+// req_gray will remain unchanged if the value is < 0
+// on sunxi devices it will inwoke fbink_sunxi_ntx_enforce_rota
+FBINK_API int
+    fbink_set_fb_info(int fbFd, int32_t bpp, int8_t rota, int32_t req_gray,
+               const FBInkConfig* restrict fbink_cfg);
+
 
 
 //

--- a/fbink.h
+++ b/fbink.h
@@ -450,8 +450,7 @@ typedef struct
 	uint8_t          ntx_boot_rota;               // deviceQuirks.ntxBootRota (Native rotation at boot)
 	NTX_ROTA_INDEX_T ntx_rota_quirk;              // deviceQuirks.ntxRotaQuirk (c.f., utils/dump.c)
 	bool    is_ntx_quirky_landscape;              // deviceQuirks.isNTX16bLandscape (rotation compensation is in effect)
-    uint8_t current_rota_native;                  // native screen rotaiton; vInfo.rotate (current rotation, c.f., <linux/fb.h>)
-    uint8_t current_rota_canonical;               // canonical screen rotation
+    uint8_t current_rota;                         // native screen rotaiton; vInfo.rotate (current rotation, c.f., <linux/fb.h>)
 	bool    can_rotate;                           // deviceQuirks.canRotate (device has a gyro)
 	bool    can_hw_invert;                        // deviceQuirks.canHWInvert (device can use EPDC inversion)
 } FBInkState;

--- a/fbink.h
+++ b/fbink.h
@@ -329,14 +329,15 @@ typedef uint8_t NTX_ROTA_INDEX_T;
 // A struct to dump FBInk's internal state into, like fbink_state_dump() would, but in C ;)
 typedef struct
 {
-	long int user_hz;                  // USER_HZ (should pretty much always be 100)
-	const char* restrict font_name;    // fbink_cfg->fontname (c.f., fontname_to_string())
-	uint32_t view_width;               // viewWidth (MAY be different than screen_width on devices with a viewport)
-	uint32_t view_height;              // viewHeight (ditto)
-	uint32_t screen_width;       // screenWidth (Effective width, c.f., is_ntx_quirky_landscape & initialize_fbink())
-	uint32_t screen_height;      // screenHeight (ditto)
-	uint32_t bpp;                // vInfo.bits_per_pixel
-	char     device_name[16];    // deviceQuirks.deviceName (short common name, no brand)
+    long int user_hz;                   // USER_HZ (should pretty much always be 100)
+    const char* restrict font_name;     // fbink_cfg->fontname (c.f., fontname_to_string())
+    uint32_t view_width;                // viewWidth (MAY be different than screen_width on devices with a viewport)
+    uint32_t view_height;               // viewHeight (ditto)
+    uint32_t screen_width;              // screenWidth (Effective width, c.f., is_ntx_quirky_landscape & initialize_fbink())
+    uint32_t screen_height;             // screenHeight (ditto)
+    uint32_t screen_stride;             // screen line length in bytes;
+    uint32_t bpp;                       // vInfo.bits_per_pixel
+    char     device_name[16];           // deviceQuirks.deviceName (short common name, no brand)
 	char     device_codename[16];       // deviceQuirks.deviceCodename
 	char     device_platform[16];       // deviceQuirks.devicePlatform (often a codename, too)
 	unsigned short int device_id;       // deviceQuirks.deviceId (decimal value, c.f., identify_device() on Kindle!)
@@ -349,18 +350,19 @@ typedef struct
 	unsigned short int max_rows;        // MAXROWS (ditto)
 	uint8_t view_hori_origin;           // viewHoriOrigin (would be non-zero on devices with a horizontal viewport)
 	uint8_t view_vert_origin;           // viewVertOrigin (origin in px of row 0, includes viewport + viewVertOffset)
-	uint8_t view_vert_offset;    // viewVertOffset (shift in px needed to vertically balance rows over viewHeight)
-	uint8_t fontsize_mult;       // FONTSIZE_MULT (current cell scaling multiplier)
-	uint8_t glyph_width;         // glyphWidth (native width of a glyph cell, i.e. unscaled)
-	uint8_t glyph_height;        // glyphHeight (native height of a glyph cell, i.e. unscaled)
-	bool    is_perfect_fit;      // deviceQuirks.isPerfectFit (horizontal column balance is perfect over viewWidth)
-	bool    is_sunxi;            // deviceQuirks.isSunxi (device is running on an AllWinner SoC)
-	bool is_kindle_legacy;    // deviceQuirks.isKindleLegacy (device is a Kindle using the original einkfb EPDC API)
-	bool is_kobo_non_mt;      // deviceQuirks.isKoboNonMT (device is a Kobo with no MultiTouch input support)
+    uint8_t view_vert_offset;           // viewVertOffset (shift in px needed to vertically balance rows over viewHeight)
+    uint8_t fontsize_mult;              // FONTSIZE_MULT (current cell scaling multiplier)
+    uint8_t glyph_width;                // glyphWidth (native width of a glyph cell, i.e. unscaled)
+    uint8_t glyph_height;               // glyphHeight (native height of a glyph cell, i.e. unscaled)
+    bool    is_perfect_fit;             // deviceQuirks.isPerfectFit (horizontal column balance is perfect over viewWidth)
+    bool    is_sunxi;                   // deviceQuirks.isSunxi (device is running on an AllWinner SoC)
+    bool is_kindle_legacy;              // deviceQuirks.isKindleLegacy (device is a Kindle using the original einkfb EPDC API)
+    bool is_kobo_non_mt;                // deviceQuirks.isKoboNonMT (device is a Kobo with no MultiTouch input support)
 	uint8_t          ntx_boot_rota;     // deviceQuirks.ntxBootRota (Native rotation at boot)
 	NTX_ROTA_INDEX_T ntx_rota_quirk;    // deviceQuirks.ntxRotaQuirk (c.f., utils/dump.c)
 	bool    is_ntx_quirky_landscape;    // deviceQuirks.isNTX16bLandscape (rotation compensation is in effect)
-	uint8_t current_rota;               // vInfo.rotate (current rotation, c.f., <linux/fb.h>)
+    uint8_t current_rota_native;        // native screen rotaiton; vInfo.rotate (current rotation, c.f., <linux/fb.h>)
+    uint8_t current_rota_canonical;     // canonical screen rotation
 	bool    can_rotate;                 // deviceQuirks.canRotate (device has a gyro)
 	bool    can_hw_invert;              // deviceQuirks.canHWInvert (device can use EPDC inversion)
 } FBInkState;

--- a/fbink.h
+++ b/fbink.h
@@ -1259,12 +1259,6 @@ FBINK_API int
     fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
 
 
-// Grants direct access to the frame buffer pointer as well as the size of the frame buffer allocation.
-// If the framebuffer is not yet allocated it will do so and return the result of the operation.
-FBINK_API int
-    fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
-
-
 // Sets the framebuffer bits per pixel and rotation and invoke a reinit afterwards
 // rota will be the rotation in natve format; use fbink_rota_canonical_to_native to convert it to canonical
 // bpp will remain unchanged if the value is < 8


### PR DESCRIPTION
These are my proposed changes for the FBInk API.

Some new members to the FBInkState struct:
~~uint8_t current_rota_native;                 // native screen rotaiton; vInfo.rotate (current rotation, c.f., <linux/fb.h>)
uint8_t current_rota_canonical;            // canonical screen rotation~~
 uint32_t    screen_stride;                     // screen line length in bytes;

A new method to access the underlying framebuffer:
// Grants direct access to the frame buffer pointer as well as the size of the frame buffer allocation.
// If the framebuffer is not yet allocated it will do so and return the result of the operation.
FBINK_API int
    fbink_get_fb_pointer(int fbfd, FBPtrInfo *fbInfo);
    

A new method to set the framebuffer rotation and bpp.
The code is mostly copied from fbdepth and probably needs some tinkering:
// Sets the framebuffer bits per pixel and rotation and invoke a reinit afterwards
// rota will be the rotation in natve format; use fbink_rota_canonical_to_native to convert it to canonical
// bpp will remain unchanged if the value is < 8
// req_gray will remain unchanged if the value is < 0
// on sunxi devices it will invoke fbink_sunxi_ntx_enforce_rota
FBINK_API int
    fbink_set_fb_info(int fbFd, int32_t bpp, int8_t rota, int32_t req_gray,
               const FBInkConfig* restrict fbink_cfg);

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/niluje/fbink/65)
<!-- Reviewable:end -->
