### PR TITLE
fbink_reinit: allow on kindle

### DIFF
--- a/fbink.c
+++ b/fbink.c
@@ -8579,15 +8579,14 @@ static int
 //           (e.g., Plato relies on HW rotation, and KOReader may change the bitdepth).
 //       TL;DR: We now monitor *any* change in bitdepth and/or rotation.
 int
-    fbink_reinit(int fbfd UNUSED_BY_KINDLE, const FBInkConfig* restrict fbink_cfg UNUSED_BY_KINDLE)
+    fbink_reinit(int fbfd, const FBInkConfig* restrict fbink_cfg)
 {
-#ifndef FBINK_FOR_KINDLE
-#	ifdef FBINK_FOR_KOBO
+#ifdef FBINK_FOR_KOBO
 	// On sunxi, the framebuffer state is meaningless, so, just do our own thing...
 	if (deviceQuirks.isSunxi) {
 		return kobo_sunxi_reinit_check(fbfd, fbink_cfg);
 	}
-#	endif
+#endif
 
 	// So, we're concerned with stuff that affects the logical & physical layout, namely, bitdepth & rotation.
 	const uint32_t old_bpp  = vInfo.bits_per_pixel;
@@ -8614,10 +8613,10 @@ int
 		goto cleanup;
 	}
 
-#	ifdef FBINK_FOR_POCKETBOOK
+#ifdef FBINK_FOR_POCKETBOOK
 	// On PocketBook, fix the broken mess that the ioctls returns...
 	pocketbook_fix_fb_info();
-#	endif
+#endif
 
 	// We want to flag each trigger independently
 	if (old_bpp != vInfo.bits_per_pixel) {
@@ -8660,12 +8659,6 @@ cleanup:
 	}
 
 	return rv;
-#else
-	// NOTE: I currently haven't found the need for any shenanigans like that on Kindle, so, make this a NOP there ;).
-	// NOTE: That said, we technically could make use of the canRotate quirk if we had an API user on Kindle that cared...
-	WARN("Reinitilization is not needed on Kindle devices :)");
-	return ERRCODE(ENOSYS);
-#endif    // !FBINK_FOR_KINDLE
 }
 
 // Public wrapper around update_pen_colors

--- a/fbink.h
+++ b/fbink.h
@@ -858,7 +858,6 @@ FBINK_API bool fbink_is_fb_quirky(void) __attribute__((pure, deprecated));
 //       and it can avoid running the same ioctl twice when an ioctl already done by init is needed to detect a state change.
 // NOTE: Using fbink_reinit does NOT lift the requirement of having to run fbink_init at least ONCE,
 //       i.e., you cannot replace the initial fbink_init call by fbink_reinit!
-// Returns -(ENOSYS) on Kindle, where this is not needed.
 // If reinitialization was *successful*, returns a bitmask with one or more of these flags set:
 // bit OK_BPP_CHANGE is set if there was a bitdepth change.
 // bit OK_ROTA_CHANGE is set if there was a rotation change.


### PR DESCRIPTION
You now have a API user :)
I use `fbink_set_fb_info` in my kindle screensaver to set rotation, and it calls `fbink_reinit` to normalize state, currently `fbink_set_fb_info` is returning the `ENOSYS` from `fbink_reinit` and i have to call fbink_init to get back to a sane state.

https://github.com/yparitcher/kindle-zmanim/blob/41ecec2a8fe8e34e6f40b970426e0b1b17351768/src/kzman.c#L274-L304
```C
void goingToSS()
{
	fbink_dump(fbfd, &dump);
	fbink_init(fbfd, &configCT);
	FBInkState state = {0};
	fbink_get_state(&configCT, &state);
	current_rota = state.current_rota;
	int ret = fbink_set_fb_info(fbfd, rota, KEEP_CURRENT_BITDEPTH, KEEP_CURRENT_GRAYSCALE, &configCT);
	if (ret && ret != -ENOSYS) {syslog(LOG_INFO, "Error rotating: %d\n", ret);}


	if (!program)
	{
		screenswitch = !screenswitch;
	}
	printSS();
}


void outOfSS()
{
	syslog(LOG_INFO, "outOfScreenSaver\n");


    syslog(LOG_INFO, "Rota: %d\n", current_rota);
	int ret = fbink_set_fb_info(fbfd, current_rota, KEEP_CURRENT_BITDEPTH, KEEP_CURRENT_GRAYSCALE, &configCT);
	if (ret && ret != -ENOSYS) {syslog(LOG_INFO, "Error reseting rotation: %d\n", ret);}


	if (access("/var/tmp/koreader.sh" , F_OK)) {
		syslog(LOG_INFO, "Restoring dump\n");
		fbink_restore(fbfd, &configRF, &dump);
	}
	fbink_free_dump_data(&dump);
}
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/niluje/fbink/67)
<!-- Reviewable:end -->
