### PR TITLE
Extend Kobo device identification code to handle mainline kernels

### DIFF
--- a/fbink.h
+++ b/fbink.h
@@ -238,9 +238,10 @@ typedef enum
 // List of i.MX device IDs for mainline kernels
 typedef enum
 {
-	DEVICE_MAINLINE_GENERIC_IMX5 = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '5',
-	DEVICE_MAINLINE_GENERIC_IMX6 = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '6',
-	DEVICE_MAINLINE_MAX          = UINT16_MAX,    // uint16_t
+	DEVICE_MAINLINE_GENERIC_IMX5       = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '5',
+	DEVICE_MAINLINE_GENERIC_IMX6       = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '6',
+	DEVICE_MAINLINE_GENERIC_SUNXI_B300 = ('A' << 8U) | ('W' << 8U) | 'B' | '3' | '0' | '0',
+	DEVICE_MAINLINE_MAX                = UINT16_MAX,    // uint16_t
 } __attribute__((packed)) MAINLINE_DEVICE_ID_E;
 
 // List of reMarkable device IDs

--- a/fbink.h
+++ b/fbink.h
@@ -288,6 +288,9 @@ typedef enum
 	DEVICE_POCKETBOOK_MAX         = UINT16_MAX,    // uint16_t
 } __attribute__((packed)) POCKETBOOK_DEVICE_ID_E;
 
+// If device detection failed...
+#define DEVICE_UNKNOWN 0U
+
 // NOTE: There's no enum for Kindles, because there are an insane number of device IDs per model,
 //       so it doesn't really fit into this model. Use the deviceName instead.
 typedef uint16_t DEVICE_ID_T;

--- a/fbink.h
+++ b/fbink.h
@@ -235,6 +235,14 @@ typedef enum
 	DEVICE_KOBO_MAX           = UINT16_MAX,    // uint16_t
 } __attribute__((packed)) KOBO_DEVICE_ID_E;
 
+// List of i.MX device IDs for mainline kernels
+typedef enum
+{
+	DEVICE_MAINLINE_GENERIC_IMX5 = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '5',
+	DEVICE_MAINLINE_GENERIC_IMX6 = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '6',
+	DEVICE_MAINLINE_MAX          = UINT16_MAX,    // uint16_t
+} __attribute__((packed)) MAINLINE_DEVICE_ID_E;
+
 // List of reMarkable device IDs
 typedef enum
 {

--- a/fbink.h
+++ b/fbink.h
@@ -235,7 +235,7 @@ typedef enum
 	DEVICE_KOBO_MAX           = UINT16_MAX,    // uint16_t
 } __attribute__((packed)) KOBO_DEVICE_ID_E;
 
-// List of i.MX device IDs for mainline kernels
+// List of device IDs for mainline kernels
 // c.f., https://github.com/NiLuJe/FBInk/issues/70#issuecomment-1242274710 for Tolinos
 typedef enum
 {

--- a/fbink.h
+++ b/fbink.h
@@ -236,8 +236,12 @@ typedef enum
 } __attribute__((packed)) KOBO_DEVICE_ID_E;
 
 // List of i.MX device IDs for mainline kernels
+// c.f., https://github.com/NiLuJe/FBInk/issues/70#issuecomment-1242274710 for Tolinos
 typedef enum
 {
+	DEVICE_MAINLINE_TOLINO_SHINE_2HD   = ('T' << 8U) | ('o' << 8U) | ('l' << 8U) | DEVICE_KOBO_GLO_HD,
+	DEVICE_MAINLINE_TOLINO_SHINE_3     = ('T' << 8U) | ('o' << 8U) | ('l' << 8U) | DEVICE_KOBO_CLARA_HD,
+	DEVICE_MAINLINE_TOLINO_VISION_5    = ('T' << 8U) | ('o' << 8U) | ('l' << 8U) | DEVICE_KOBO_LIBRA_H2O,
 	DEVICE_MAINLINE_GENERIC_IMX5       = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '5',
 	DEVICE_MAINLINE_GENERIC_IMX6       = ('i' << 8U) | ('.' << 8U) | 'M' | 'X' | '6',
 	DEVICE_MAINLINE_GENERIC_SUNXI_B300 = ('A' << 8U) | ('W' << 8U) | 'B' | '3' | '0' | '0',

--- a/fbink_cozette.c
+++ b/fbink_cozette.c
@@ -773,4 +773,3 @@ static const unsigned char*
 		return cozette_block1[0];
 	}
 }
-

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -988,6 +988,8 @@ static void
 				fclose(fp);
 
 				// Do try a last stand with the mainline device id codepath...
+				// We don't call set_kobo_quirks w/ DEVICE_INVALID as we don't want an early warning...
+				// (It's only ever used when we return early without falling back to another detection mechanism).
 				return identify_mainline();
 			}
 
@@ -999,7 +1001,6 @@ static void
 				     HWCONFIG_DEVICE);
 				fclose(fp);
 
-				// Don't call set_kobo_quirks w/ DEVICE_INVALID as we don't want an early warning...
 				return identify_mainline();
 			}
 

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1120,7 +1120,7 @@ static void
 				kobo_id = DEVICE_MAINLINE_GENERIC_IMX6;
 				break;
 			} else if (strcmp(line, "fsl,imx50") == 0) {
-				kobo_id = DEVICE_MAINLINE_GENERIC_IMX6;
+				kobo_id = DEVICE_MAINLINE_GENERIC_IMX5;
 				break;
 			}
 		}

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1076,7 +1076,7 @@ static void
 				// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
 				// NOTE: Some Tolinos *will* end up with a Kobo ID, here, because of lax matches:
 				//       e.g., the Shine 3 will be matched as a Clara HD, and the Vision 5 as a Libra.
-				const unsigned short int kobo_id = kobo_ids[payload[KOBO_HWCFG_PCB]];
+				unsigned short int kobo_id = kobo_ids[payload[KOBO_HWCFG_PCB]];
 
 				// And now for the fun part, the few device variants that use the same PCB ID...
 				if (kobo_id == DEVICE_KOBO_AURA_H2O_2 || kobo_id == DEVICE_KOBO_AURA_SE) {

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -987,7 +987,6 @@ static void
 				WARN("Failed to read the NTX HWConfig entry on `%s`", HWCONFIG_DEVICE);
 				fclose(fp);
 
-				set_kobo_quirks(DEVICE_INVALID);
 				// Do try a last stand with the mainline device id codepath...
 				return identify_mainline();
 			}

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1074,7 +1074,8 @@ static void
 				}
 
 				// Assuming we actually *know* about this PCB ID...
-				// NOTE: Wanted: PCB IDs for the Tolinos ;).
+				// NOTE: Some Tolinos *will* end up with a Kobo IDs, here, because of lax matches:
+				//       e.g., the Shine 3 will be matched as a Clara HD, and the Vision 5 as a Libra.
 				if (kobo_id != DEVICE_UNKNOWN) {
 					// ...we can do this, as accurately as if onboard were mounted ;).
 					set_kobo_quirks(kobo_id);
@@ -1082,9 +1083,10 @@ static void
 					// Get out now, we're done!
 					return;
 				}
+			}
 		} else {
-			// Should hopefully never happen, since there's a good chance we'd have caught a SIGSEGV before that,
-			// if alloca failed ;).
+			// Should hopefully never happen,
+			// since there's a good chance we'd have caught a SIGSEGV before that if alloca failed ;).
 			WARN("Empty NTX HWConfig payload?");
 		}
 	}

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1074,7 +1074,7 @@ static void
 				     (sizeof(kobo_ids) / sizeof(*kobo_ids)));
 			} else {
 				// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
-				// NOTE: Some Tolinos *will* end up with a Kobo ID, here, because of lax matches:
+				// NOTE: Some Tolinos *will* end up with a Kobo ID here, because of lax matches:
 				//       e.g., the Shine 3 will be matched as a Clara HD, and the Vision 5 as a Libra.
 				unsigned short int kobo_id = kobo_ids[payload[KOBO_HWCFG_PCB]];
 

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -873,6 +873,40 @@ static void
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.devicePlatform, "Mark 3?", sizeof(deviceQuirks.devicePlatform) - 1U);
 			break;
+		case DEVICE_MAINLINE_TOLINO_SHINE_2HD:    // Tolino Shine 2HD (Glo HD-ish)
+			// Mainline kernels expect to use the same set of ioctls as on Mk. 7+, even on older devices.
+			deviceQuirks.isKoboMk7 = true;
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceName, "Shine 2HD", sizeof(deviceQuirks.deviceName) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "Mainline", sizeof(deviceQuirks.deviceCodename) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.devicePlatform, "Tolino", sizeof(deviceQuirks.devicePlatform) - 1U);
+			break;
+		case DEVICE_MAINLINE_TOLINO_SHINE_3:    // Tolino Shine 3 (Clara HD-ish)
+			deviceQuirks.isKoboMk7 = true;
+			deviceQuirks.screenDPI = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceName, "Shine 3", sizeof(deviceQuirks.deviceName) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "Mainline", sizeof(deviceQuirks.deviceCodename) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.devicePlatform, "Tolino", sizeof(deviceQuirks.devicePlatform) - 1U);
+			break;
+		case DEVICE_MAINLINE_TOLINO_VISION_5:    // Tolino Vision 5 (Libra H2O-ish)
+			deviceQuirks.isKoboMk7    = true;
+			deviceQuirks.ntxBootRota  = FB_ROTATE_UR;
+			deviceQuirks.canRotate    = true;
+			deviceQuirks.ntxRotaQuirk = NTX_ROTA_SANE;
+			deviceQuirks.screenDPI    = 300U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceName, "Vision 5", sizeof(deviceQuirks.deviceName) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "Mainline", sizeof(deviceQuirks.deviceCodename) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.devicePlatform, "Tolino", sizeof(deviceQuirks.devicePlatform) - 1U);
+			break;
 		case DEVICE_MAINLINE_GENERIC_IMX5:
 			// Generic fallback for i.MX5 devices on mainline kernels
 			deviceQuirks.screenDPI = 212U;
@@ -1116,25 +1150,15 @@ static void
 			// Keep this in the same order as Documentation/devicetree/bindings/arm/fsl.yaml to ease updates
 			if (strcmp(line, "kobo,aura") == 0) {
 				kobo_id = DEVICE_KOBO_AURA;
-				set_kobo_quirks(kobo_id);
 				break;
 			} else if (strcmp(line, "kobo,tolino-shine2hd") == 0) {
-				kobo_id = DEVICE_KOBO_GLO_HD;
-				set_kobo_quirks(kobo_id);
-				// Mainline kernels expect to use the same set of ioctls as on Mk. 7+, even on older devices.
-				deviceQuirks.isKoboMk7 = true;
-				// Flawfinder: ignore
-				strncpy(deviceQuirks.deviceName, "Shine 2 HD", sizeof(deviceQuirks.deviceName) - 1U);
-				// Flawfinder: ignore
-				strncpy(deviceQuirks.deviceCodename, "??", sizeof(deviceQuirks.deviceCodename) - 1U);
-				// Flawfinder: ignore
-				strncpy(deviceQuirks.devicePlatform, "Tolino", sizeof(deviceQuirks.devicePlatform) - 1U);
+				kobo_id = DEVICE_MAINLINE_TOLINO_SHINE_2HD;
 				break;
 			} else if (strcmp(line, "kobo,tolino-shine3") == 0) {
-				kobo_id = DEVICE_KOBO_CLARA_HD;
+				kobo_id = DEVICE_MAINLINE_TOLINO_SHINE_3;
 				break;
 			} else if (strcmp(line, "kobo,tolino-vision5") == 0) {
-				kobo_id = DEVICE_KOBO_LIBRA_H2O;
+				kobo_id = DEVICE_MAINLINE_TOLINO_VISION_5;
 				break;
 			} else if (strcmp(line, "kobo,clarahd") == 0) {
 				kobo_id = DEVICE_KOBO_CLARA_HD;
@@ -1165,8 +1189,9 @@ static void
 
 	// NOTE: Like rcS, if all else fails, assume it's an old Freescale Trilogy...
 	if (kobo_id == DEVICE_INVALID) {
-		set_kobo_quirks(DEVICE_UNKNOWN);
+		kobo_id = DEVICE_UNKNOWN;
 	}
+	set_kobo_quirks(kobo_id);
 }
 
 #	elif defined(FBINK_FOR_REMARKABLE)

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -940,7 +940,7 @@ static void
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.deviceName, "B300", sizeof(deviceQuirks.deviceName) - 1U);
 			// Flawfinder: ignore
-			strncpy(deviceQuirks.deviceCodename, "??", sizeof(deviceQuirks.deviceCodename) - 1U);
+			strncpy(deviceQuirks.deviceCodename, "Mainline", sizeof(deviceQuirks.deviceCodename) - 1U);
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.devicePlatform, "Mark 8", sizeof(deviceQuirks.devicePlatform) - 1U);
 			break;
@@ -1074,6 +1074,8 @@ static void
 				     (sizeof(kobo_ids) / sizeof(*kobo_ids)));
 			} else {
 				// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
+				// NOTE: Some Tolinos *will* end up with a Kobo ID, here, because of lax matches:
+				//       e.g., the Shine 3 will be matched as a Clara HD, and the Vision 5 as a Libra.
 				const unsigned short int kobo_id = kobo_ids[payload[KOBO_HWCFG_PCB]];
 
 				// And now for the fun part, the few device variants that use the same PCB ID...
@@ -1108,8 +1110,6 @@ static void
 				}
 
 				// Assuming we actually *know* about this PCB ID...
-				// NOTE: Some Tolinos *will* end up with a Kobo IDs, here, because of lax matches:
-				//       e.g., the Shine 3 will be matched as a Clara HD, and the Vision 5 as a Libra.
 				if (kobo_id != DEVICE_UNKNOWN) {
 					// ...we can do this, as accurately as if onboard were mounted ;).
 					set_kobo_quirks(kobo_id);
@@ -1136,8 +1136,6 @@ static void
     identify_mainline(void)
 {
 	// This is aimed at mainline kernels, c.f., https://github.com/NiLuJe/FBInk/issues/70
-
-	// Default to an identification failure
 	unsigned short int kobo_id = DEVICE_INVALID;
 	FILE*              fp      = fopen(MAINLINE_DEVICE_ID_SYSFS, "re");
 	if (!fp) {

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1000,7 +1000,7 @@ static void
 				     HWCONFIG_DEVICE);
 				fclose(fp);
 
-				set_kobo_quirks(DEVICE_INVALID);
+				// Don't call set_kobo_quirks w/ DEVICE_INVALID as we don't want an early warning...
 				return identify_mainline();
 			}
 

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -894,6 +894,22 @@ static void
 			// Flawfinder: ignore
 			strncpy(deviceQuirks.devicePlatform, "Mark >= 6", sizeof(deviceQuirks.devicePlatform) - 1U);
 			break;
+		case DEVICE_MAINLINE_GENERIC_SUNXI_B300:
+			// Generic fallback for sunxi B300 devices
+			deviceQuirks.isSunxi       = true;
+			deviceQuirks.hasEclipseWfm = true;
+			deviceQuirks.canHWInvert   = false;
+			deviceQuirks.ntxBootRota   = FB_ROTATE_UR;    // Assume nothing
+			deviceQuirks.canRotate     = true;
+			deviceQuirks.ntxRotaQuirk  = NTX_ROTA_SUNXI;
+			deviceQuirks.screenDPI     = 227U;
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceName, "B300", sizeof(deviceQuirks.deviceName) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.deviceCodename, "??", sizeof(deviceQuirks.deviceCodename) - 1U);
+			// Flawfinder: ignore
+			strncpy(deviceQuirks.devicePlatform, "Mark 8", sizeof(deviceQuirks.devicePlatform) - 1U);
+			break;
 		default:
 			// Print something slightly different if we completely failed to even compute a kobo_id...
 			if (kobo_id == (unsigned short int) -1) {
@@ -1121,6 +1137,9 @@ static void
 				break;
 			} else if (strcmp(line, "fsl,imx50") == 0) {
 				kobo_id = DEVICE_MAINLINE_GENERIC_IMX5;
+				break;
+			} else if (strcmp(line, "allwinner,sun8iw15p1") == 0) {
+				kobo_id = DEVICE_MAINLINE_GENERIC_SUNXI_B300;
 				break;
 			}
 		}

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1025,8 +1025,6 @@ static void
 		}
 		fclose(fp);
 
-		// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
-		unsigned short int kobo_id = DEVICE_INVALID;
 		// Mainly to make GCC happy, because if alloca failed, we're screwed anyway.
 		if (payload) {
 			/*
@@ -1041,7 +1039,8 @@ static void
 				     payload[KOBO_HWCFG_PCB],
 				     (sizeof(kobo_ids) / sizeof(*kobo_ids)));
 			} else {
-				kobo_id = kobo_ids[payload[KOBO_HWCFG_PCB]];
+				// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
+				const unsigned short int kobo_id = kobo_ids[payload[KOBO_HWCFG_PCB]];
 
 				// And now for the fun part, the few device variants that use the same PCB ID...
 				if (kobo_id == DEVICE_KOBO_AURA_H2O_2 || kobo_id == DEVICE_KOBO_AURA_SE) {
@@ -1073,20 +1072,20 @@ static void
 						}
 					}
 				}
-			}
+
+				// Assuming we actually *know* about this PCB ID...
+				// NOTE: Wanted: PCB IDs for the Tolinos ;).
+				if (kobo_id != DEVICE_UNKNOWN) {
+					// ...we can do this, as accurately as if onboard were mounted ;).
+					set_kobo_quirks(kobo_id);
+
+					// Get out now, we're done!
+					return;
+				}
 		} else {
 			// Should hopefully never happen, since there's a good chance we'd have caught a SIGSEGV before that,
 			// if alloca failed ;).
 			WARN("Empty NTX HWConfig payload?");
-		}
-		// Assuming we actually *know* about this PCB ID...
-		// NOTE: Wanted: PCB IDs for the Tolinos ;).
-		if (kobo_id != DEVICE_INVALID && kobo_id != DEVICE_UNKNOWN) {
-			// ...we can do this, as accurately as if onboard were mounted ;).
-			set_kobo_quirks(kobo_id);
-
-			// Get out now, we're done!
-			return;
 		}
 	}
 

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -912,7 +912,7 @@ static void
 			break;
 		default:
 			// Print something slightly different if we completely failed to even compute a kobo_id...
-			if (kobo_id == (unsigned short int) -1) {
+			if (kobo_id == DEVICE_INVALID) {
 				WARN("Failed to compute a Kobo device code");
 			} else {
 				WARN("Unidentified Kobo device code (%hu)", kobo_id);
@@ -955,8 +955,8 @@ static void
 		} else {
 			WARN("Failed to read the Kobo version tag (%zu)", size);
 			// NOTE: Make it clear we failed to identify the device...
-			//       i.e., by passing UINT16_MAX instead of 0U, which we use to flag old !NTX devices.
-			set_kobo_quirks((unsigned short int) -1);
+			//       i.e., by passing DEVICE_INVALID instead of DEVICE_UNKNOWN, which we use to flag old !NTX devices.
+			set_kobo_quirks(DEVICE_INVALID);
 		}
 
 		// Get out now, we're done!
@@ -986,8 +986,9 @@ static void
 				WARN("Failed to read the NTX HWConfig entry on `%s`", HWCONFIG_DEVICE);
 				fclose(fp);
 				// NOTE: Make it clear we failed to identify the device...
-				//       i.e., by passing UINT16_MAX instead of 0U, which we use to flag old !NTX devices.
-				set_kobo_quirks((unsigned short int) -1);
+				//       i.e., by passing DEVICE_INVALID instead of DEVICE_UNKNOWN,
+				//       which we use to flag old !NTX devices.
+				set_kobo_quirks(DEVICE_INVALID);
 
 				// Do try a last stand with the mainline device id codepath...
 				return identify_mainline();
@@ -1013,7 +1014,7 @@ static void
 				WARN("Error reading NTX HWConfig payload (unexpected length)");
 				fclose(fp);
 				// NOTE: Make it clear we failed to identify the device...
-				set_kobo_quirks((unsigned short int) -1);
+				set_kobo_quirks(DEVICE_INVALID);
 				return;
 			}
 
@@ -1026,7 +1027,7 @@ static void
 		fclose(fp);
 
 		// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
-		unsigned short int kobo_id = 0U;
+		unsigned short int kobo_id = DEVICE_UNKNOWN;
 		// Mainly to make GCC happy, because if alloca failed, we're screwed anyway.
 		if (payload) {
 			/*
@@ -1098,7 +1099,7 @@ static void
 	// This is aimed at mainline kernels, c.f., https://github.com/NiLuJe/FBInk/issues/70
 
 	// Default to an identification failure
-	unsigned short int kobo_id = (unsigned short int) -1U;
+	unsigned short int kobo_id = DEVICE_INVALID;
 	FILE*              fp      = fopen(MAINLINE_DEVICE_ID_SYSFS, "re");
 	if (!fp) {
 		ELOG("Couldn't find a DTB sysfs entry!");
@@ -1148,9 +1149,9 @@ static void
 	}
 
 	set_kobo_quirks(kobo_id);
-	
+
 	// Mainline kernels expect to use the same set of ioctls as on Mk. 7+, even on older devices.
-	if (kobo_id != (unsigned short int) -1U) {
+	if (kobo_id != DEVICE_INVALID) {
 		deviceQuirks.isKoboMk7 = true;
 	}
 }

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1114,9 +1114,19 @@ static void
 			// Keep this in the same order as Documentation/devicetree/bindings/arm/fsl.yaml to ease updates
 			if (strcmp(line, "kobo,aura") == 0) {
 				kobo_id = DEVICE_KOBO_AURA;
+				set_kobo_quirks(kobo_id);
 				break;
 			} else if (strcmp(line, "kobo,tolino-shine2hd") == 0) {
 				kobo_id = DEVICE_KOBO_GLO_HD;
+				set_kobo_quirks(kobo_id);
+				// Mainline kernels expect to use the same set of ioctls as on Mk. 7+, even on older devices.
+				deviceQuirks.isKoboMk7 = true;
+				// Flawfinder: ignore
+				strncpy(deviceQuirks.deviceName, "Shine 2 HD", sizeof(deviceQuirks.deviceName) - 1U);
+				// Flawfinder: ignore
+				strncpy(deviceQuirks.deviceCodename, "??", sizeof(deviceQuirks.deviceCodename) - 1U);
+				// Flawfinder: ignore
+				strncpy(deviceQuirks.devicePlatform, "Tolino", sizeof(deviceQuirks.devicePlatform) - 1U);
 				break;
 			} else if (strcmp(line, "kobo,tolino-shine3") == 0) {
 				kobo_id = DEVICE_KOBO_CLARA_HD;
@@ -1153,14 +1163,7 @@ static void
 
 	// NOTE: Like rcS, if all else fails, assume it's an old Freescale Trilogy...
 	if (kobo_id == DEVICE_INVALID) {
-		kobo_id = DEVICE_UNKNOWN;
-	}
-
-	set_kobo_quirks(kobo_id);
-
-	// Mainline kernels expect to use the same set of ioctls as on Mk. 7+, even on older devices.
-	if (kobo_id != DEVICE_INVALID) {
-		deviceQuirks.isKoboMk7 = true;
+		set_kobo_quirks(DEVICE_UNKNOWN);
 	}
 }
 

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1027,7 +1027,7 @@ static void
 		fclose(fp);
 
 		// As per /bin/kobo_config.sh, match PCB IDs to Product IDs via a LUT...
-		unsigned short int kobo_id = DEVICE_UNKNOWN;
+		unsigned short int kobo_id = DEVICE_INVALID;
 		// Mainly to make GCC happy, because if alloca failed, we're screwed anyway.
 		if (payload) {
 			/*
@@ -1080,15 +1080,20 @@ static void
 			// if alloca failed ;).
 			WARN("Empty NTX HWConfig payload?");
 		}
-		// And now we can do this, as accurately as if onboard were mounted ;).
-		set_kobo_quirks(kobo_id);
+		// Assuming we actually *know* about this PCB ID...
+		// NOTE: Wanted: PCB IDs for the Tolinos ;).
+		if (kobo_id != DEVICE_INVALID && kobo_id != DEVICE_UNKNOWN) {
+			// ...we can do this, as accurately as if onboard were mounted ;).
+			set_kobo_quirks(kobo_id);
 
-		// Get out now, we're done!
-		return;
+			// Get out now, we're done!
+			return;
+		}
 	}
 
 	// NOTE: And if we went this far, it means onboard isn't mounted/Nickel never ran,
-	//       *and* either we're not on an NTX board, or mmcblk0 is unmounted.
+	//       *and* either we're not on an NTX board, or mmcblk0 is unmounted;
+	//       or we failed to detect a device with either of those two methods.
 	//       That usually points to a device running a mainline kernel, so let's poke at the DTB...
 	return identify_mainline();
 }

--- a/fbink_device_id.c
+++ b/fbink_device_id.c
@@ -1148,6 +1148,11 @@ static void
 	}
 
 	set_kobo_quirks(kobo_id);
+	
+	// Mainline kernels expect to use the same set of ioctls as on Mk. 7+, even on older devices.
+	if (kobo_id != (unsigned short int) -1U) {
+		deviceQuirks.isKoboMk7 = true;
+	}
 }
 
 #	elif defined(FBINK_FOR_REMARKABLE)

--- a/fbink_device_id.h
+++ b/fbink_device_id.h
@@ -149,8 +149,12 @@ static const char* kobo_disp_res[] = { "800x600",    "1024x758",    "1024x768", 
 static const char* kobo_disp_busw[] = { "8Bits", "16Bits", "8Bits_mirror", "16Bits_mirror", "NC" };
 */
 
+// And for mainline kernels, this is where we poke for device identification
+#                define MAINLINE_DEVICE_ID_SYSFS "/sys/firmware/devicetree/base/compatible"
+
 static void set_kobo_quirks(unsigned short int);
 static void identify_kobo(void);
+static void identify_mainline(void);
 #        elif defined(FBINK_FOR_REMARKABLE)
 static void identify_remarkable(void);
 #        elif defined(FBINK_FOR_POCKETBOOK)

--- a/fbink_device_id.h
+++ b/fbink_device_id.h
@@ -28,6 +28,9 @@
 
 #include <linux/fs.h>
 
+// Used as a sentinel value during device detection
+#define DEVICE_INVALID UINT16_MAX
+
 #ifndef FBINK_FOR_LINUX
 #	if defined(FBINK_FOR_KOBO) || defined(FBINK_FOR_CERVANTES)
 // NOTE: This is NTX's homegrown hardware tagging, c.f., arch/arm/mach-imx/ntx_hwconfig.h in a Kobo kernel, for instance

--- a/fbink_device_id.h
+++ b/fbink_device_id.h
@@ -112,12 +112,13 @@ static const char* kobo_pcbs[] = {
 // And match (more or less accurately, for some devices) that to what we've come to know as a device code,
 // because that's what we actually care about...
 // c.f., tools/pcb_to_ids.py
-static const unsigned short int kobo_ids[] = {
-	0,   0,   0, 0, 0, 0,   0,   0,   0,   0,   0,   0, 310, 0,   0,   0, 0, 0,   0, 0,   310, 320, 0, 0, 330, 0, 0,
-	340, 350, 0, 0, 0, 0,   0,   360, 360, 0,   330, 0, 0,   0,   370, 0, 0, 0,   0, 371, 0,   0,   0, 0, 0,   0, 0,
-	0,   373, 0, 0, 0, 375, 374, 0,   0,   375, 0,   0, 375, 0,   0,   0, 0, 0,   0, 376, 376, 377, 0, 0, 0,   0, 0,
-	382, 0,   0, 0, 0, 0,   384, 0,   0,   0,   0,   0, 0,   387, 0,   0, 0, 383, 0, 0,   388, 0,   0, 0
-};
+static const unsigned short int kobo_ids[] = { 0,   0,   0, 0,   0,   0,     0,   0,   0,   0,   0,   0,   310, 0,   0,
+					       0,   0,   0, 0,   0,   310,   320, 0,   0,   330, 0,   0,   340, 350, 0,
+					       0,   0,   0, 0,   360, 360,   0,   330, 0,   0,   0,   370, 0,   0,   0,
+					       0,   371, 0, 0,   0,   32627, 0,   0,   0,   0,   373, 0,   0,   0,   375,
+					       374, 0,   0, 375, 0,   0,     375, 0,   0,   0,   0,   0,   0,   376, 376,
+					       377, 0,   0, 0,   0,   0,     382, 0,   0,   0,   0,   0,   384, 0,   0,
+					       0,   0,   0, 0,   387, 0,     0,   0,   383, 0,   0,   388, 0,   0,   0 };
 
 // Same idea, but for the various NTX/Kobo Display Panels...
 /*

--- a/tools/pcb_to_ids.py
+++ b/tools/pcb_to_ids.py
@@ -10,7 +10,20 @@ data = "./Kobo_PCB_IDs.txt"
 
 with open(data, "r") as f:
 	for line in f:
-		if line.startswith("E60610D"):
+		# NOTE: Start with the Tolinos, as we have a complete PCB ID for them,
+		#       c.f., https://github.com/NiLuJe/FBInk/issues/70#issuecomment-1242274710
+		if line.startswith("E60QF0"):
+			# Tolino Shine 2HD
+			print("32627,")
+#		elif line.startswith("E60K00"):
+#			# NOTE: Caught by the Clara HD match
+#			# Tolino Shine 3
+#			print("32632,")
+		elif line.startswith("E70K0M"):
+			# NOTE: Its actual DTB says E70K0M, but at the same index as E70K00, which is the Libra...
+			# Tolino Vision 5
+			print("32640,")
+		elif line.startswith("E60610D"):
 			# NOTE: This is an educated guess. kobo_config puts every E60610* in the "trilogy" basket...
 			# Touch C (trilogy) [320]
 			print("320,")


### PR DESCRIPTION
Fix #70, where all the gory details lie ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/niluje/fbink/71)
<!-- Reviewable:end -->
