### PR TITLE
fix `make -n`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ else
 	RANLIB?=gcc-ranlib
 endif
 
+# For use in recursive calls we don't want `make -n` to follow through.
+SUBMAKE = $(MAKE)
+
 DEBUG_CFLAGS:=-Og -fno-omit-frame-pointer -pipe -g
 # Fallback CFLAGS, we honor the env first and foremost!
 OPT_CFLAGS:=-O2 -fomit-frame-pointer -pipe
@@ -784,7 +787,7 @@ libunibreak.built:
 	--enable-static \
 	--disable-shared \
 	$(if $(PIC),--with-pic=yes,)
-	$(MAKE) -C libunibreak-staged
+	$(SUBMAKE) -C libunibreak-staged
 	touch "$@"
 
 libi2c.built:
@@ -808,7 +811,7 @@ libevdev.built:
 	--prefix='$(CURDIR)/libevdev-staged' \
 	--enable-static \
 	--disable-shared && \
-	$(MAKE) install
+	$(SUBMAKE) install
 	touch "$@"
 
 ifeq "$(CC_IS_CLANG)" "1"


### PR DESCRIPTION
Don't try to build libevdev / libunibreak, e.g. when called with: `make CROSS_TC=arm-kobo-linux-gnueabihf KOBO=1 ftrace -n`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NiLuJe/FBInk/78)
<!-- Reviewable:end -->
